### PR TITLE
Wait for CityStore token for all action types

### DIFF
--- a/docs/Dispatcher.md
+++ b/docs/Dispatcher.md
@@ -108,11 +108,14 @@ The usage of `waitFor()` can be chained, for example:
 
 ```
 FlightPriceStore.dispatchToken =
-  flightDispatcher.register(function(payload)) {
-    if (payload.actionType === 'country-update' || payload.actionType === 'city-update') {
-      flightDispatcher.waitFor([CityStore.dispatchToken]);
-      FlightPriceStore.price =
-        getFlightPriceStore(CountryStore.country, CityStore.city);
+  flightDispatcher.register(function(payload) {
+    switch (payload.actionType) {
+      case 'country-update':
+      case 'city-update':
+        flightDispatcher.waitFor([CityStore.dispatchToken]);
+        FlightPriceStore.price =
+          getFlightPriceStore(CountryStore.country, CityStore.city);
+        break;
   }
 });
 ```


### PR DESCRIPTION
Thank you for writing this document. I'm just learning Flux and this seemed to be very beneficial.

I changed the final example because I think that `getFlightPriceStore` would need to wait for the `CityStore.dispatchToken` for either action type.
