### PR TITLE
Fixed typo on propTypes in chat example

### DIFF
--- a/examples/flux-chat/js/components/MessageListItem.react.js
+++ b/examples/flux-chat/js/components/MessageListItem.react.js
@@ -18,7 +18,7 @@ var ReactPropTypes = React.PropTypes;
 
 var MessageListItem = React.createClass({
 
-  props: {
+  propTypes: {
     message: ReactPropTypes.object
   },
 

--- a/examples/flux-chat/js/components/ThreadListItem.react.js
+++ b/examples/flux-chat/js/components/ThreadListItem.react.js
@@ -20,7 +20,7 @@ var ReactPropTypes = React.PropTypes;
 
 var ThreadListItem = React.createClass({
 
-  props: {
+  propTypes: {
     thread: ReactPropTypes.object,
     currentThreadID: ReactPropTypes.string
   },


### PR DESCRIPTION
The property "propTypes" of React components in chat example was written as "props" instead, thus they weren't taken into account!
