### PR TITLE
Clean up website/publish.sh script

### DIFF
--- a/website/publish.sh
+++ b/website/publish.sh
@@ -1,20 +1,22 @@
 #!/bin/bash
 
+set -e
+
 # Start in website/ even if run from root directory
 cd "$(dirname "$0")"
 
-cd ../../flux-gh-pages && \
-git checkout -- . && \
-git clean -dfx && \
-git fetch && \
-git rebase && \
-rm -Rf * && \
-cd ../flux/website && \
-node server/generate.js && \
-cp -R build/flux/* ../../flux-gh-pages/ && \
-rm -Rf build/ && \
-cd ../../flux-gh-pages && \
-git add --all && \
-git commit -m "update website" && \
-git push && \
+cd ../../flux-gh-pages
+git checkout -- .
+git clean -dfx
+git fetch
+git rebase
+rm -Rf *
+cd ../flux/website
+node server/generate.js
+cp -R build/flux/* ../../flux-gh-pages/
+rm -Rf build/
+cd ../../flux-gh-pages
+git add --all
+git commit -m "update website"
+git push
 cd ../flux/website


### PR DESCRIPTION
Reduce noise by replacing the repeated `&&` chain with use of `set -e`,
which will cause the script to bail on the first command that exits with
a non-zero exit code.
