### PR TITLE
Keep use of "ChatConstants" consistent

### DIFF
--- a/examples/flux-chat/js/dispatcher/ChatAppDispatcher.js
+++ b/examples/flux-chat/js/dispatcher/ChatAppDispatcher.js
@@ -12,8 +12,6 @@
 
 var ChatConstants = require('../constants/ChatConstants');
 var Dispatcher = require('./Dispatcher');
-
-// var merge = require('react/lib/merge');
 var copyProperties = require('react/lib/copyProperties');
 
 var PayloadSources = ChatConstants.PayloadSources;


### PR DESCRIPTION
The `PayloadSources` constants are already defined, but they weren't being used. Though nothing uses the `sources` property in the example, it's probably best to reference the constants directly from `ChatConstants` to keep its use consistent.
