### PR TITLE
Remove erroneous paren from dispatcher example

### DIFF
--- a/docs/Dispatcher.md
+++ b/docs/Dispatcher.md
@@ -62,7 +62,7 @@ flightDispatcher.dispatch({
 This payload is digested by `CityStore`:
 
 ```
-flightDispatcher.register(function(payload)) {
+flightDispatcher.register(function(payload) {
   if (payload.actionType === 'city-update') {
     CityStore.city = payload.selectedCity;
   }


### PR DESCRIPTION
Found an extra paren in one of the code examples on the dispatcher page. Thought I'd fix it quick.
