### PR TITLE
Chat example: prevent unnecessary message wipe

### DIFF
--- a/examples/flux-chat/js/ChatExampleData.js
+++ b/examples/flux-chat/js/ChatExampleData.js
@@ -13,6 +13,7 @@
 module.exports = {
 
   init: function() {
+    if(localStorage.hasOwnProperty('messages')) return;
     localStorage.clear();
     localStorage.setItem('messages', JSON.stringify([
       {


### PR DESCRIPTION
Minor change...
In the chat example, we don't have to refill store with sample messages, if we already have some data in localStorage...
Existing data is already pulled by ChatWebAPIUtils...
