### PR TITLE
Minor enhancements from justin

### DIFF
--- a/examples/flux-chat/js/app.js
+++ b/examples/flux-chat/js/app.js
@@ -18,6 +18,7 @@ var ChatApp = require('./components/ChatApp.react');
 var ChatExampleData = require('./ChatExampleData');
 var ChatWebAPIUtils = require('./utils/ChatWebAPIUtils');
 var React = require('react');
+window.React = React; // export for http://fb.me/react-devtools
 
 ChatExampleData.init(); // load example data into localstorage
 

--- a/examples/flux-chat/js/components/MessageComposer.react.js
+++ b/examples/flux-chat/js/components/MessageComposer.react.js
@@ -36,10 +36,14 @@ var MessageComposer = React.createClass({
   },
 
   _onChange: function(event, value) {
-    this.setState({text: event.target.value});
+    // ENTER_KEY_CODE handled by _onKeyDown
+    if (event.target.value !== "\n") {
+      this.setState({text: event.target.value});
+    }
   },
 
   _onKeyDown: function(event) {
+    // Trap the ENTER_KEY_CODE to send the message
     if (event.keyCode === ENTER_KEY_CODE) {
       var text = this.state.text.trim();
       if (text) {

--- a/examples/flux-chat/js/components/MessageComposer.react.js
+++ b/examples/flux-chat/js/components/MessageComposer.react.js
@@ -44,7 +44,7 @@ var MessageComposer = React.createClass({
 
   _onKeyDown: function(event) {
     // Trap the ENTER_KEY_CODE to send the message
-    if (event.keyCode === ENTER_KEY_CODE) {
+    if (event.keyCode === ENTER_KEY_CODE && event.shiftKey === false) {
       var text = this.state.text.trim();
       if (text) {
         ChatMessageActionCreators.createMessage(text);

--- a/examples/flux-chat/js/components/MessageListItem.react.js
+++ b/examples/flux-chat/js/components/MessageListItem.react.js
@@ -16,6 +16,15 @@ var React = require('react');
 
 var ReactPropTypes = React.PropTypes;
 
+// Copied from http://stackoverflow.com/a/10772475/1009332
+// Would make more sense to use markdown parser or other library
+var sanitizeHTML = function (string, white, black) {
+  if (!white) white = "b|i|p|br";//allowed tags
+  if (!black) black = "script|object|embed";//complete remove tags
+  var e = new RegExp("(<(" + black + ")[^>]*>.*</\\2>|(?!<[/]?(" + white + ")(\\s[^<]*>|[/]>|>))<[^<>]*>|(?!<[^<>\\s]+)\\s[^</>]+(?=[/>]))", "gi");
+  return string.replace(e, "");
+}
+
 var MessageListItem = React.createClass({
 
   propTypes: {
@@ -24,16 +33,19 @@ var MessageListItem = React.createClass({
 
   render: function() {
     var message = this.props.message;
+    var sanitizedText = sanitizeHTML(message.text, false, false);
+    var text = sanitizedText.replace(/\n/g, "<br />");
     return (
       <li className="message-list-item">
         <h5 className="message-author-name">{message.authorName}</h5>
         <div className="message-time">
           {message.date.toLocaleTimeString()}
         </div>
-        <div className="message-text">{message.text}</div>
+        <div className="message-text" dangerouslySetInnerHTML={{__html: text}} />
       </li>
     );
   }
+  //<div className="message-text">{message.text}</div>
 
 });
 

--- a/examples/flux-chat/js/components/MessageSection.react.js
+++ b/examples/flux-chat/js/components/MessageSection.react.js
@@ -18,6 +18,10 @@ var MessageStore = require('../stores/MessageStore');
 var React = require('react');
 var ThreadStore = require('../stores/ThreadStore');
 
+// Need to setup message registration
+// We need to ensure that both MessageStore and ThreadStore have finished initializing before this "require"
+require('../stores/ThreadstoreMessageRegistration');
+
 function getStateFromStores() {
   return {
     messages: MessageStore.getAllForCurrentThread(),

--- a/examples/flux-chat/js/components/ThreadSection.react.js
+++ b/examples/flux-chat/js/components/ThreadSection.react.js
@@ -13,7 +13,6 @@
  */
 
 var React = require('react');
-var MessageStore = require('../stores/MessageStore');
 var ThreadListItem = require('../components/ThreadListItem.react');
 var ThreadStore = require('../stores/ThreadStore');
 var UnreadThreadStore = require('../stores/UnreadThreadStore');

--- a/examples/flux-chat/js/stores/MessageStore.js
+++ b/examples/flux-chat/js/stores/MessageStore.js
@@ -131,30 +131,5 @@ MessageStore.dispatchToken = ChatAppDispatcher.register(function(payload) {
 
 });
 
-ThreadStore.dispatchToken = ChatAppDispatcher.register(function(payload) {
-  var action = payload.action;
-
-  switch(action.type) {
-
-    case ActionTypes.CLICK_THREAD:
-      ThreadStore.threadSelected(action.threadID);
-      ThreadStore.emitChange();
-      break;
-
-    case ActionTypes.RECEIVE_RAW_MESSAGES:
-      ThreadStore.init(action.rawMessages);
-      ThreadStore.emitChange();
-      break;
-
-    case ActionTypes.CREATE_MESSAGE:
-      ChatAppDispatcher.waitFor([MessageStore.dispatchToken]);
-      var currentThreadMessages = MessageStore.getAllForCurrentThread();
-      var lastMessage = currentThreadMessages[currentThreadMessages.length - 1];
-      ThreadStore.setLastMessageOnCurrentThread(lastMessage);
-      ThreadStore.emitChange();
-    default:
-    // do nothing
-  }
-});
 
 module.exports = MessageStore;

--- a/examples/flux-chat/js/stores/MessageStore.js
+++ b/examples/flux-chat/js/stores/MessageStore.js
@@ -115,9 +115,7 @@ MessageStore.dispatchToken = ChatAppDispatcher.register(function(payload) {
     case ActionTypes.CREATE_MESSAGE:
       var message = MessageStore.getCreatedMessageData(action.text);
       _messages[message.id] = message;
-      ThreadStore.setLastMessageOnCurrentThread(message);
       MessageStore.emitChange();
-      ThreadStore.emitChange();
       break;
 
     case ActionTypes.RECEIVE_RAW_MESSAGES:
@@ -131,6 +129,32 @@ MessageStore.dispatchToken = ChatAppDispatcher.register(function(payload) {
       // do nothing
   }
 
+});
+
+ThreadStore.dispatchToken = ChatAppDispatcher.register(function(payload) {
+  var action = payload.action;
+
+  switch(action.type) {
+
+    case ActionTypes.CLICK_THREAD:
+      ThreadStore.threadSelected(action.threadID);
+      ThreadStore.emitChange();
+      break;
+
+    case ActionTypes.RECEIVE_RAW_MESSAGES:
+      ThreadStore.init(action.rawMessages);
+      ThreadStore.emitChange();
+      break;
+
+    case ActionTypes.CREATE_MESSAGE:
+      ChatAppDispatcher.waitFor([MessageStore.dispatchToken]);
+      var currentThreadMessages = MessageStore.getAllForCurrentThread();
+      var lastMessage = currentThreadMessages[currentThreadMessages.length - 1];
+      ThreadStore.setLastMessageOnCurrentThread(lastMessage);
+      ThreadStore.emitChange();
+    default:
+    // do nothing
+  }
 });
 
 module.exports = MessageStore;

--- a/examples/flux-chat/js/stores/MessageStore.js
+++ b/examples/flux-chat/js/stores/MessageStore.js
@@ -115,7 +115,9 @@ MessageStore.dispatchToken = ChatAppDispatcher.register(function(payload) {
     case ActionTypes.CREATE_MESSAGE:
       var message = MessageStore.getCreatedMessageData(action.text);
       _messages[message.id] = message;
+      ThreadStore.setLastMessageOnCurrentThread(message);
       MessageStore.emitChange();
+      ThreadStore.emitChange();
       break;
 
     case ActionTypes.RECEIVE_RAW_MESSAGES:

--- a/examples/flux-chat/js/stores/ThreadStore.js
+++ b/examples/flux-chat/js/stores/ThreadStore.js
@@ -98,8 +98,11 @@ var ThreadStore = merge(EventEmitter.prototype, {
 
   getCurrent: function() {
     return this.get(this.getCurrentID());
-  }
+  },
 
+  setLastMessageOnCurrentThread: function(message) {
+    this.getCurrent().lastMessage = message;
+  }
 });
 
 ThreadStore.dispatchToken = ChatAppDispatcher.register(function(payload) {
@@ -118,6 +121,12 @@ ThreadStore.dispatchToken = ChatAppDispatcher.register(function(payload) {
       ThreadStore.emitChange();
       break;
 
+    // Trying to ensure the MessageStore handled the event first didn't work
+    // Why is MessageStore always {} ?? Circular dependency issue probably
+    //case ActionTypes.CREATE_MESSAGE:
+    //  ChatAppDispatcher.waitFor([MessageStore.dispatchToken]);
+    //  ThreadStore.setLastMessageOnCurrentThread();
+    //  ThreadStore.emitChange();
     default:
       // do nothing
   }

--- a/examples/flux-chat/js/stores/ThreadStore.js
+++ b/examples/flux-chat/js/stores/ThreadStore.js
@@ -102,33 +102,11 @@ var ThreadStore = merge(EventEmitter.prototype, {
 
   setLastMessageOnCurrentThread: function(message) {
     this.getCurrent().lastMessage = message;
-  }
-});
+  },
 
-ThreadStore.dispatchToken = ChatAppDispatcher.register(function(payload) {
-  var action = payload.action;
-
-  switch(action.type) {
-
-    case ActionTypes.CLICK_THREAD:
-      _currentID = action.threadID;
-      _threads[_currentID].lastMessage.isRead = true;
-      ThreadStore.emitChange();
-      break;
-
-    case ActionTypes.RECEIVE_RAW_MESSAGES:
-      ThreadStore.init(action.rawMessages);
-      ThreadStore.emitChange();
-      break;
-
-    // Trying to ensure the MessageStore handled the event first didn't work
-    // Why is MessageStore always {} ?? Circular dependency issue probably
-    //case ActionTypes.CREATE_MESSAGE:
-    //  ChatAppDispatcher.waitFor([MessageStore.dispatchToken]);
-    //  ThreadStore.setLastMessageOnCurrentThread();
-    //  ThreadStore.emitChange();
-    default:
-      // do nothing
+  threadSelected: function(threadID) {
+    _currentID = threadID;
+    _threads[_currentID].lastMessage.isRead = true;
   }
 
 });

--- a/examples/flux-chat/js/stores/ThreadStoreMessageRegistration.js
+++ b/examples/flux-chat/js/stores/ThreadStoreMessageRegistration.js
@@ -1,0 +1,49 @@
+/**
+ * This file is provided by Facebook for testing and evaluation purposes
+ * only. Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @jsx React.DOM
+ */
+
+/* This code cannot into ThreadStore.js due because that would create a circular dependency between MessageStore
+   and ThreadStore. */
+
+var ChatAppDispatcher = require('../dispatcher/ChatAppDispatcher');
+var ThreadStore = require('../stores/ThreadStore');
+var MessageStore = require('../stores/MessageStore');
+var ChatConstants = require('../constants/ChatConstants');
+var ActionTypes = ChatConstants.ActionTypes;
+
+ThreadStore.dispatchToken = ChatAppDispatcher.register(function(payload) {
+  var action = payload.action;
+
+  switch(action.type) {
+
+    case ActionTypes.CLICK_THREAD:
+      ThreadStore.threadSelected(action.threadID);
+      ThreadStore.emitChange();
+      break;
+
+    case ActionTypes.RECEIVE_RAW_MESSAGES:
+      ThreadStore.init(action.rawMessages);
+      ThreadStore.emitChange();
+      break;
+
+    case ActionTypes.CREATE_MESSAGE:
+      ChatAppDispatcher.waitFor([MessageStore.dispatchToken]);
+      var currentThreadMessages = MessageStore.getAllForCurrentThread();
+      var lastMessage = currentThreadMessages[currentThreadMessages.length - 1];
+      ThreadStore.setLastMessageOnCurrentThread(lastMessage);
+      ThreadStore.emitChange();
+    default:
+    // do nothing
+  }
+});
+


### PR DESCRIPTION
I'd like to get some feedback if these changes are helpful.

In particular, I wanted to have the ThreadStore listen for new messages created, and then pull the last message from the MessageStore. However, due to some circular dependency issue, I could not get that work. The code that doesn't work is commented out in ThreadStore.

I'd also like to know if having the MessageStore send a message to update the ThreadStore directly is acceptable. Clearly, the MessageStore is dependent on the ThreadStore. I'm guessing that having this dependency only go in one direction was critical.