### PR TITLE
detect missing action during dispatch dispatch

### DIFF
--- a/src/Dispatcher.js
+++ b/src/Dispatcher.js
@@ -186,6 +186,10 @@ class Dispatcher {
       !this._isDispatching,
       'Dispatch.dispatch(...): Cannot dispatch in the middle of a dispatch.'
     );
+    invariant(
+        typeof payload.action === 'undefined',
+        'Dispatch.dispatch(...): Cannot dispatch payload with missing action.'
+    );
     this._startDispatching(payload);
     try {
       for (var id in this._callbacks) {


### PR DESCRIPTION
related to https://github.com/facebook/flux/issues/58
Missing constant for action will result in matching undefined within the stores.
This simply kills the dispatch process and throws an error if the payload.action is undefined
