### PR TITLE
Enable React devtools by exposing React (setting window.React)

### DIFF
--- a/examples/flux-chat/js/app.js
+++ b/examples/flux-chat/js/app.js
@@ -18,6 +18,7 @@ var ChatApp = require('./components/ChatApp.react');
 var ChatExampleData = require('./ChatExampleData');
 var ChatWebAPIUtils = require('./utils/ChatWebAPIUtils');
 var React = require('react');
+window.React = React; // export for http://fb.me/react-devtools
 
 ChatExampleData.init(); // load example data into localstorage
 


### PR DESCRIPTION
Very simple change to enable react-devtools in Chrome.
