### PR TITLE
Fix newline appearing in textarea in ChatApp

### DIFF
--- a/examples/flux-chat/js/components/MessageComposer.react.js
+++ b/examples/flux-chat/js/components/MessageComposer.react.js
@@ -41,6 +41,7 @@ var MessageComposer = React.createClass({
 
   _onKeyDown: function(event) {
     if (event.keyCode === ENTER_KEY_CODE) {
+      event.preventDefault();
       var text = this.state.text.trim();
       if (text) {
         ChatMessageActionCreators.createMessage(text);


### PR DESCRIPTION
Call event.preventDefault() to stop a newline being added to the
textarea in the MessageComposer component after sending a
message with enter.
