### PR TITLE
Added cursor pointer to none active thread items

### DIFF
--- a/examples/flux-chat/css/chatapp.css
+++ b/examples/flux-chat/css/chatapp.css
@@ -49,6 +49,7 @@
 
 .thread-list-item {
   border-bottom: 1px solid #ccc;
+  cursor: pointer;
 }
 
 .thread-list:hover .thread-list-item:hover {
@@ -63,6 +64,7 @@
 .thread-list:hover .thread-list-item.active,
 .thread-list:hover .thread-list-item.active:hover {
   background-color: #efefff;
+  cursor: default;
 }
 
 .message-author-name,


### PR DESCRIPTION
Its a UX flaw that the thread items doesn't seem clickable to the user.
