### PR TITLE
Replacing global declarations

### DIFF
--- a/examples/flux-todomvc/js/stores/__tests__/TodoStore-test.js
+++ b/examples/flux-todomvc/js/stores/__tests__/TodoStore-test.js
@@ -16,6 +16,9 @@ jest.dontMock('react/lib/merge');
 describe('TodoStore', function() {
 
   var TodoConstants = require('../../constants/TodoConstants');
+  var AppDispatcher;
+  var TodoStore;
+  var callback;
 
   // mock actions inside dispatch payloads
   var actionTodoCreate = {


### PR DESCRIPTION
Making global declarations to be locally. Hoisted the declaration of `AppDispatcher`, `TodoStore` and `callback` into the context of the main describe function, making them locally available for this context, instead of defining them as global variables.

Matching issue: #80  
