### PR TITLE
Update examples to 0.12 and use object-assign

### DIFF
--- a/docs/TodoList.md
+++ b/docs/TodoList.md
@@ -56,7 +56,7 @@ Now we are ready to create a dispatcher. Here is an naive example of a Dispatche
 
 ```javascript
 var Promise = require('es6-promise').Promise;
-var assign = require('react/lib/Object.assign');
+var assign = require('object-assign');
 
 var _callbacks = [];
 var _promises = [];
@@ -111,8 +111,7 @@ Now we are all set to create a dispatcher that is more specific to our app, whic
 
 ```javascript
 var Dispatcher = require('./Dispatcher');
-
-var assign = require('react/lib/Object.assign');
+var assign = require('object-assign');
 
 var AppDispatcher = assign({}, Dispatcher.prototype, {
 
@@ -145,7 +144,7 @@ We can use Node's EventEmitter to get started with a store. We need EventEmitter
 var AppDispatcher = require('../dispatcher/AppDispatcher');
 var EventEmitter = require('events').EventEmitter;
 var TodoConstants = require('../constants/TodoConstants');
-var assign = require('react/lib/Object.assign');
+var assign = require('object-assign');
 
 var CHANGE_EVENT = 'change';
 

--- a/examples/flux-chat/js/dispatcher/ChatAppDispatcher.js
+++ b/examples/flux-chat/js/dispatcher/ChatAppDispatcher.js
@@ -12,7 +12,7 @@
 
 var ChatConstants = require('../constants/ChatConstants');
 var Dispatcher = require('flux').Dispatcher;
-var assign = require('react/lib/Object.assign');
+var assign = require('object-assign');
 
 var PayloadSources = ChatConstants.PayloadSources;
 

--- a/examples/flux-chat/js/stores/MessageStore.js
+++ b/examples/flux-chat/js/stores/MessageStore.js
@@ -15,7 +15,7 @@ var ChatConstants = require('../constants/ChatConstants');
 var ChatMessageUtils = require('../utils/ChatMessageUtils');
 var EventEmitter = require('events').EventEmitter;
 var ThreadStore = require('../stores/ThreadStore');
-var assign = require('react/lib/Object.assign');
+var assign = require('object-assign');
 
 var ActionTypes = ChatConstants.ActionTypes;
 var CHANGE_EVENT = 'change';

--- a/examples/flux-chat/js/stores/ThreadStore.js
+++ b/examples/flux-chat/js/stores/ThreadStore.js
@@ -14,7 +14,7 @@ var ChatAppDispatcher = require('../dispatcher/ChatAppDispatcher');
 var ChatConstants = require('../constants/ChatConstants');
 var ChatMessageUtils = require('../utils/ChatMessageUtils');
 var EventEmitter = require('events').EventEmitter;
-var assign = require('react/lib/Object.assign');
+var assign = require('object-assign');
 
 var ActionTypes = ChatConstants.ActionTypes;
 var CHANGE_EVENT = 'change';

--- a/examples/flux-chat/js/stores/UnreadThreadStore.js
+++ b/examples/flux-chat/js/stores/UnreadThreadStore.js
@@ -15,7 +15,7 @@ var ChatConstants = require('../constants/ChatConstants');
 var EventEmitter = require('events').EventEmitter;
 var MessageStore = require('../stores/MessageStore');
 var ThreadStore = require('../stores/ThreadStore');
-var assign = require('react/lib/Object.assign');
+var assign = require('object-assign');
 
 var ActionTypes = ChatConstants.ActionTypes;
 var CHANGE_EVENT = 'change';

--- a/examples/flux-chat/js/stores/__tests__/UnreadThreadStore-test.js
+++ b/examples/flux-chat/js/stores/__tests__/UnreadThreadStore-test.js
@@ -11,7 +11,7 @@
  */
 
 jest.dontMock('../UnreadThreadStore');
-jest.dontMock('react/lib/Object.assign');
+jest.dontMock('object-assign');
 
 describe('UnreadThreadStore', function() {
 

--- a/examples/flux-chat/package.json
+++ b/examples/flux-chat/package.json
@@ -7,12 +7,13 @@
   "dependencies": {
     "flux": "^2.0.0",
     "react": "^0.12.0"
+    "object-assign": "^1.0.0",
   },
   "devDependencies": {
     "browserify": "^6.2.0",
     "envify": "^3.0.0",
     "jest-cli": "~0.1.17",
-    "reactify": "~0.15.2",
+    "reactify": "^0.15.2",
     "uglify-js": "~2.4.15",
     "watchify": "^2.1.1"
   },

--- a/examples/flux-todomvc/js/dispatcher/AppDispatcher.js
+++ b/examples/flux-todomvc/js/dispatcher/AppDispatcher.js
@@ -12,7 +12,8 @@
  */
 
 var Dispatcher = require('flux').Dispatcher;
-var assign = require('react/lib/Object.assign');
+var assign = require('object-assign');
+
 var AppDispatcher = assign(new Dispatcher(), {
 
   /**

--- a/examples/flux-todomvc/js/stores/TodoStore.js
+++ b/examples/flux-todomvc/js/stores/TodoStore.js
@@ -12,7 +12,7 @@
 var AppDispatcher = require('../dispatcher/AppDispatcher');
 var EventEmitter = require('events').EventEmitter;
 var TodoConstants = require('../constants/TodoConstants');
-var assign = require('react/lib/Object.assign');
+var assign = require('object-assign');
 
 var CHANGE_EVENT = 'change';
 

--- a/examples/flux-todomvc/js/stores/__tests__/TodoStore-test.js
+++ b/examples/flux-todomvc/js/stores/__tests__/TodoStore-test.js
@@ -11,7 +11,7 @@
 
 jest.dontMock('../../constants/TodoConstants');
 jest.dontMock('../TodoStore');
-jest.dontMock('react/lib/Object.assign');
+jest.dontMock('object-assign');
 
 describe('TodoStore', function() {
 

--- a/examples/flux-todomvc/package.json
+++ b/examples/flux-todomvc/package.json
@@ -6,6 +6,7 @@
   "main": "js/app.js",
   "dependencies": {
     "flux": "^2.0.0",
+    "object-assign": "^1.0.0",
     "react": "^0.12.0"
   },
   "devDependencies": {


### PR DESCRIPTION
0.12 deprecates usage of merge and copyProperties and autofactories

Object.assign is provided in react/lib/Object.assign as of now, but may
move to a more freely accessible place in the future.
