### PR TITLE
Remove src folder from .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-src/
 Makefile
 Flux.js
 CONTRIBUTING.md


### PR DESCRIPTION
The package installed via NPM is empty except for index.js.
