### PR TITLE
Select action type

### DIFF
--- a/src/Dispatcher.js
+++ b/src/Dispatcher.js
@@ -125,14 +125,20 @@ class Dispatcher {
    * @param {function} callback
    * @return {string}
    */
-  register(actionType, callback) {
-    if (typeof actionType === "function") {
-      callback = actionType;
-      actionType = "*";
+  register(actionTypes, callback) {
+    if (typeof actionTypes === "function") {
+      callback = actionTypes;
+      actionTypes = "*";
     }
-    if (!this._actionTypes[actionType]) this._actionTypes[actionType] = {};
+    if (!Array.isArray(actionTypes)) {
+      actionTypes = [actionTypes];
+    }
     var id = _prefix + _lastID++;
-    this._actionTypes[actionType][id] = this._callbacks[id] = callback;
+    for (var i = 0, l = actionTypes.length; i < l; i++) {
+      var actionType = actionTypes[i];
+      if (!this._actionTypes[actionType]) this._actionTypes[actionType] = {};
+      this._actionTypes[actionType][id] = this._callbacks[id] = callback;
+    }
     return id;
   }
 

--- a/src/__tests__/Dispatcher-test.js
+++ b/src/__tests__/Dispatcher-test.js
@@ -17,16 +17,19 @@ describe('Dispatcher', function() {
   var dispatcher;
   var callbackA;
   var callbackB;
+  var callbackC;
 
   beforeEach(function() {
     dispatcher = new Dispatcher();
     callbackA = jest.genMockFunction();
     callbackB = jest.genMockFunction();
+    callbackC = jest.genMockFunction();
   });
 
   it('should execute all subscriber callbacks', function() {
     dispatcher.register(callbackA);
     dispatcher.register(callbackB);
+    dispatcher.register("sample-event", callbackC);
 
     var payload = {};
     dispatcher.dispatch(payload);
@@ -37,6 +40,9 @@ describe('Dispatcher', function() {
     expect(callbackB.mock.calls.length).toBe(1);
     expect(callbackB.mock.calls[0][0]).toBe(payload);
 
+    expect(callbackC.mock.calls.length).toBe(1);
+    expect(callbackC.mock.calls[0][0]).toBe(payload);
+
     dispatcher.dispatch(payload);
 
     expect(callbackA.mock.calls.length).toBe(2);
@@ -44,6 +50,34 @@ describe('Dispatcher', function() {
 
     expect(callbackB.mock.calls.length).toBe(2);
     expect(callbackB.mock.calls[1][0]).toBe(payload);
+
+    expect(callbackC.mock.calls.length).toBe(2);
+    expect(callbackC.mock.calls[1][0]).toBe(payload);
+  });
+
+  it('should execute specific subscriber callback', function() {
+    dispatcher.register(callbackA);
+    dispatcher.register(callbackB);
+    dispatcher.register("sample-event", callbackC);
+
+    var payload = {actionType: "sample-event"};
+    dispatcher.dispatch(payload);
+
+    expect(callbackA.mock.calls.length).toBe(0);
+
+    expect(callbackB.mock.calls.length).toBe(0);
+
+    expect(callbackC.mock.calls.length).toBe(1);
+    expect(callbackC.mock.calls[0][0]).toBe(payload);
+
+    dispatcher.dispatch(payload);
+
+    expect(callbackA.mock.calls.length).toBe(0);
+
+    expect(callbackB.mock.calls.length).toBe(0);
+
+    expect(callbackC.mock.calls.length).toBe(2);
+    expect(callbackC.mock.calls[1][0]).toBe(payload);
   });
 
   it('should wait for callbacks registered earlier', function() {

--- a/src/__tests__/Dispatcher-test.js
+++ b/src/__tests__/Dispatcher-test.js
@@ -55,7 +55,7 @@ describe('Dispatcher', function() {
     expect(callbackC.mock.calls[1][0]).toBe(payload);
   });
 
-  it('should execute specific subscriber callback', function() {
+  it('should execute specific subscriber callback via string', function() {
     dispatcher.register(callbackA);
     dispatcher.register(callbackB);
     dispatcher.register("sample-event", callbackC);
@@ -78,6 +78,50 @@ describe('Dispatcher', function() {
 
     expect(callbackC.mock.calls.length).toBe(2);
     expect(callbackC.mock.calls[1][0]).toBe(payload);
+  });
+
+  it('should execute specific subscriber callback via array', function() {
+    dispatcher.register(callbackA);
+    dispatcher.register(callbackB);
+    dispatcher.register(["sample-event", "other-event"], callbackC);
+
+    var payload = {actionType: "sample-event"};
+    dispatcher.dispatch(payload);
+
+    expect(callbackA.mock.calls.length).toBe(0);
+
+    expect(callbackB.mock.calls.length).toBe(0);
+
+    expect(callbackC.mock.calls.length).toBe(1);
+    expect(callbackC.mock.calls[0][0]).toBe(payload);
+
+    dispatcher.dispatch(payload);
+
+    expect(callbackA.mock.calls.length).toBe(0);
+
+    expect(callbackB.mock.calls.length).toBe(0);
+
+    expect(callbackC.mock.calls.length).toBe(2);
+    expect(callbackC.mock.calls[1][0]).toBe(payload);
+
+    payload = {actionType: "other-event"};
+    dispatcher.dispatch(payload);
+
+    expect(callbackA.mock.calls.length).toBe(0);
+
+    expect(callbackB.mock.calls.length).toBe(0);
+
+    expect(callbackC.mock.calls.length).toBe(3);
+    expect(callbackC.mock.calls[2][0]).toBe(payload);
+
+    dispatcher.dispatch(payload);
+
+    expect(callbackA.mock.calls.length).toBe(0);
+
+    expect(callbackB.mock.calls.length).toBe(0);
+
+    expect(callbackC.mock.calls.length).toBe(4);
+    expect(callbackC.mock.calls[3][0]).toBe(payload);
   });
 
   it('should wait for callbacks registered earlier', function() {


### PR DESCRIPTION
### Abstract

The more the registered actions, the more time the dispatcher spent time to choice matched callback.
So this p-r enables to give actionType to register action optionally.

### Usage

```javascript
var dispatcher = require("flux").Dispatcher;

dispatcher.register("some-event", function(payload){
  // without checking payload.actionType
})

var payload = {
  actionType: "some-event"
}
dispatcher.dispatch(payload); //=> fire registered callback with "some-event"
```

