### PR TITLE
Slight refactor of message creation

### DIFF
--- a/examples/flux-chat/js/actions/ChatMessageActionCreators.js
+++ b/examples/flux-chat/js/actions/ChatMessageActionCreators.js
@@ -24,8 +24,6 @@ module.exports = {
       type: ActionTypes.CREATE_MESSAGE,
       text: text
     });
-    var message = MessageStore.getCreatedMessageData(text);
-    ChatWebAPIUtils.createMessage(message);
   }
 
 };

--- a/examples/flux-chat/js/actions/ChatMessageActionCreators.js
+++ b/examples/flux-chat/js/actions/ChatMessageActionCreators.js
@@ -13,17 +13,21 @@
 var ChatAppDispatcher = require('../dispatcher/ChatAppDispatcher');
 var ChatConstants = require('../constants/ChatConstants');
 var ChatWebAPIUtils = require('../utils/ChatWebAPIUtils');
+var ChatMessageUtils = require('../utils/ChatMessageUtils');
 var MessageStore = require('../stores/MessageStore');
 
 var ActionTypes = ChatConstants.ActionTypes;
 
 module.exports = {
 
-  createMessage: function(text) {
+  createMessage: function(text, currentThreadID) {
     ChatAppDispatcher.handleViewAction({
       type: ActionTypes.CREATE_MESSAGE,
-      text: text
+      text: text,
+      currentThreadID: currentThreadID
     });
+    var message = ChatMessageUtils.getCreatedMessageData(text, currentThreadID);
+    ChatWebAPIUtils.createMessage(message);
   }
 
 };

--- a/examples/flux-chat/js/components/MessageComposer.react.js
+++ b/examples/flux-chat/js/components/MessageComposer.react.js
@@ -17,6 +17,10 @@ var ENTER_KEY_CODE = 13;
 
 var MessageComposer = React.createClass({
 
+  propTypes: {
+    threadID: React.PropTypes.string.isRequired
+  },
+
   getInitialState: function() {
     return {text: ''};
   },
@@ -42,7 +46,7 @@ var MessageComposer = React.createClass({
       event.preventDefault();
       var text = this.state.text.trim();
       if (text) {
-        ChatMessageActionCreators.createMessage(text);
+        ChatMessageActionCreators.createMessage(text, this.props.threadID);
       }
       this.setState({text: ''});
     }

--- a/examples/flux-chat/js/components/MessageSection.react.js
+++ b/examples/flux-chat/js/components/MessageSection.react.js
@@ -57,7 +57,7 @@ var MessageSection = React.createClass({
         <ul className="message-list" ref="messageList">
           {messageListItems}
         </ul>
-        <MessageComposer />
+        <MessageComposer threadID={this.state.thread.id}/>
       </div>
     );
   },

--- a/examples/flux-chat/js/stores/MessageStore.js
+++ b/examples/flux-chat/js/stores/MessageStore.js
@@ -13,6 +13,7 @@
 var ChatAppDispatcher = require('../dispatcher/ChatAppDispatcher');
 var ChatConstants = require('../constants/ChatConstants');
 var ChatMessageUtils = require('../utils/ChatMessageUtils');
+var ChatWebAPIUtils = require('../utils/ChatWebAPIUtils');
 var EventEmitter = require('events').EventEmitter;
 var ThreadStore = require('../stores/ThreadStore');
 var assign = require('object-assign');
@@ -53,7 +54,7 @@ var MessageStore = assign({}, EventEmitter.prototype, {
   addChangeListener: function(callback) {
     this.on(CHANGE_EVENT, callback);
   },
-  
+
   removeChangeListener: function(callback) {
     this.removeListener(CHANGE_EVENT, callback);
   },
@@ -89,18 +90,6 @@ var MessageStore = assign({}, EventEmitter.prototype, {
 
   getAllForCurrentThread: function() {
     return this.getAllForThread(ThreadStore.getCurrentID());
-  },
-
-  getCreatedMessageData: function(text) {
-    var timestamp = Date.now();
-    return {
-      id: 'm_' + timestamp,
-      threadID: ThreadStore.getCurrentID(),
-      authorName: 'Bill', // hard coded for the example
-      date: new Date(timestamp),
-      text: text,
-      isRead: true
-    };
   }
 
 });
@@ -117,8 +106,12 @@ MessageStore.dispatchToken = ChatAppDispatcher.register(function(payload) {
       break;
 
     case ActionTypes.CREATE_MESSAGE:
-      var message = MessageStore.getCreatedMessageData(action.text);
+      var message = ChatMessageUtils.getCreatedMessageData(
+        action.text,
+        ThreadStore.getCurrentID()
+      );
       _messages[message.id] = message;
+      ChatWebAPIUtils.createMessage(message);
       MessageStore.emitChange();
       break;
 

--- a/examples/flux-chat/js/stores/MessageStore.js
+++ b/examples/flux-chat/js/stores/MessageStore.js
@@ -13,7 +13,6 @@
 var ChatAppDispatcher = require('../dispatcher/ChatAppDispatcher');
 var ChatConstants = require('../constants/ChatConstants');
 var ChatMessageUtils = require('../utils/ChatMessageUtils');
-var ChatWebAPIUtils = require('../utils/ChatWebAPIUtils');
 var EventEmitter = require('events').EventEmitter;
 var ThreadStore = require('../stores/ThreadStore');
 var assign = require('object-assign');
@@ -108,10 +107,9 @@ MessageStore.dispatchToken = ChatAppDispatcher.register(function(payload) {
     case ActionTypes.CREATE_MESSAGE:
       var message = ChatMessageUtils.getCreatedMessageData(
         action.text,
-        ThreadStore.getCurrentID()
+        action.currentThreadID
       );
       _messages[message.id] = message;
-      ChatWebAPIUtils.createMessage(message);
       MessageStore.emitChange();
       break;
 

--- a/examples/flux-chat/js/utils/ChatMessageUtils.js
+++ b/examples/flux-chat/js/utils/ChatMessageUtils.js
@@ -21,6 +21,18 @@ module.exports = {
       text: rawMessage.text,
       isRead: rawMessage.threadID === currentThreadID
     };
+  },
+
+  getCreatedMessageData: function(text, currentThreadID) {
+    var timestamp = Date.now();
+    return {
+      id: 'm_' + timestamp,
+      threadID: currentThreadID,
+      authorName: 'Bill', // hard coded for the example
+      date: new Date(timestamp),
+      text: text,
+      isRead: true
+    };
   }
 
 };


### PR DESCRIPTION
Since the `getCreatedMessageData` method of the `MessageStore` is just a message specific utility, it makes more sense to put it in `ChatMessageUtils`. The debatable part here is that I then moved the call to the APIs create method to the store. The primary motivation for that was the availability of `currentThreadID`, however, this may also be more maintainable because it keeps the optimistic store update close to the server/API create call.