### PR TITLE
Link to dispatcher API from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Flux is available as a [npm module](https://www.npmjs.org/package/flux), so you 
 var Dispatcher = require('flux').Dispatcher;
 ```
 
+Take a look at the [dispatcher API and some examples](http://facebook.github.io/flux/docs/dispatcher.html#content).
 
 ## Building Flux from a Cloned Repo
 Clone the repo and navigate into the resulting `flux` directory.  Then run `npm install`.


### PR DESCRIPTION
Added a quick link to the dispatcher API and examples on the flux docs, from the dispatcher section of the README.md. This will make it easy for those interested to see how the dispatcher can be used. 