### PR TITLE
Clean up 'Building Flux from a Cloned Repo' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ var Dispatcher = require('flux').Dispatcher;
 Take a look at the [dispatcher API and some examples](http://facebook.github.io/flux/docs/dispatcher.html#content).
 
 ## Building Flux from a Cloned Repo
-Clone the repo and navigate into the resulting `flux` directory.  Then run `npm install`.
+Clone the repo and navigate into the resulting `flux` directory, then run `npm install`.
 
 This will run [Gulp](http://gulpjs.com/)-based build tasks automatically and produce the file Flux.js, which you can then require as a module. 
 


### PR DESCRIPTION
Merge the two sentences together into one concise instruction. 
From: Clone the repo and navigate into the resulting `flux` directory. Then run `npm install`.
To: Clone the repo and navigate into the resulting `flux` directory, then run `npm install`.

This only makes changes to the README.md, and does not break Flux in any way.