### PR TITLE
Make sure clean actually completes first.

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -4,6 +4,7 @@ var gReplace = require('gulp-replace');
 var browserify = require('browserify');
 var source = require('vinyl-source-stream');
 var del = require('del');
+var runSequence = require('run-sequence');
 
 var browserifyConfig = {
   entries: ['./index.js'],
@@ -22,12 +23,17 @@ gulp.task('lib', function() {
 
 });
 
-gulp.task('browserify', function() {
+gulp.task('browserify', ['lib'], function() {
   return browserify(browserifyConfig)
           .bundle()
           .pipe(source('Flux.js'))
           .pipe(gulp.dest('./dist/'))
 });
 
-gulp.task('publish', ['clean', 'default']);
-gulp.task('default', ['lib', 'browserify']);
+gulp.task('build', ['lib', 'browserify']);
+
+gulp.task('publish', function(cb) {
+  runSequence('clean', 'build', cb);
+});
+
+gulp.task('default', ['build']);

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "gulp-replace": "^0.4.0",
     "jest-cli": "~0.1.17",
     "react-tools": "^0.12.0",
+    "run-sequence": "^1.0.2",
     "vinyl-source-stream": "^0.1.1"
   }
 }


### PR DESCRIPTION
Should fix #162.

This will now ensure 2 things:
1. That the `browserify` task doesn't run before the `lib` task. This wasn't the bug we saw but *it could happen*.
2. That when running the `publish` task, we wait for `clean` to finish. The previous setup would run that at the same time as `lib` and `browserify`.