### PR TITLE
Website build is broken

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -3,7 +3,7 @@
     "start": "node server/server.js"
   },
   "dependencies": {
-    "React": "~0.12.0",
+    "react": "~0.12.0",
     "optimist": "0.6.0",
     "react-page-middleware": "git://github.com/facebook/react-page-middleware.git",
     "connect": "3.3.3",


### PR DESCRIPTION
`React` (capitalize) is not registered in npm, resulting a 404 on `npm install`

Bug found here : https://github.com/facebook/jest/pull/283