### PR TITLE
Fixing the wrong sub-directory.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,4 +7,4 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-module.exports.Dispatcher = require('./lib/Dispatcher')
+module.exports.Dispatcher = require('./src/Dispatcher')


### PR DESCRIPTION
The `Dispatcher` module is in the `src` directory and not `lib`