### PR TITLE
fix typo

### DIFF
--- a/examples/flux-chat/README.md
+++ b/examples/flux-chat/README.md
@@ -18,7 +18,7 @@ To build the project, first run this command:
 `npm start`
 
 This will perform an initial build and start a watcher process that will
-update build.js with any changes you wish to make.  This watcher is
+update bundle.js with any changes you wish to make.  This watcher is
 based on [Browserify](http://browserify.org/) and
 [Watchify](https://github.com/substack/watchify), and it transforms
 React's JSX syntax into standard JavaScript with

--- a/examples/flux-todomvc/README.md
+++ b/examples/flux-todomvc/README.md
@@ -143,7 +143,7 @@ To build the project, first run this command:
 
     npm start
 
-This will perform an initial build and start a watcher process that will update build.js with any changes you wish to make.  This watcher is based on [Browserify](http://browserify.org/) and [Watchify](https://github.com/substack/watchify), and it transforms React's JSX syntax into standard JavaScript with [Reactify](https://github.com/andreypopp/reactify).
+This will perform an initial build and start a watcher process that will update bundle.js with any changes you wish to make.  This watcher is based on [Browserify](http://browserify.org/) and [Watchify](https://github.com/substack/watchify), and it transforms React's JSX syntax into standard JavaScript with [Reactify](https://github.com/andreypopp/reactify).
 
 To run the app, spin up an HTTP server and visit http://localhost/.../todomvc-flux/.  Or simply open the index.html file in a browser.
 


### PR DESCRIPTION
Since I find no *build.js* in this repo , I suppose it to be *bundle.js* generated by ```npm start```:relaxed: