### PR TITLE
Move internal Dispatcher _lastID counter to be class bound

### DIFF
--- a/dist/Flux.js
+++ b/dist/Flux.js
@@ -28,7 +28,6 @@ module.exports.Dispatcher = require('./lib/Dispatcher')
 
 var invariant = require('./invariant');
 
-var _lastID = 1;
 var _prefix = 'ID_';
 
 /**
@@ -120,6 +119,7 @@ var _prefix = 'ID_';
  */
 
   function Dispatcher() {
+    this._lastID = 1;
     this._callbacks = {};
     this._isPending = {};
     this._isHandled = {};
@@ -135,7 +135,7 @@ var _prefix = 'ID_';
    * @return {string}
    */
   Dispatcher.prototype.register=function(callback) {
-    var id = _prefix + _lastID++;
+    var id = _prefix + this._lastID++;
     this._callbacks[id] = callback;
     return id;
   };

--- a/src/Dispatcher.js
+++ b/src/Dispatcher.js
@@ -15,7 +15,6 @@
 
 var invariant = require('./invariant');
 
-var _lastID = 1;
 var _prefix = 'ID_';
 
 /**
@@ -107,6 +106,7 @@ var _prefix = 'ID_';
  */
 class Dispatcher {
   constructor() {
+    this._lastID = 1;
     this._callbacks = {};
     this._isPending = {};
     this._isHandled = {};
@@ -122,7 +122,7 @@ class Dispatcher {
    * @return {string}
    */
   register(callback) {
-    var id = _prefix + _lastID++;
+    var id = _prefix + this._lastID++;
     this._callbacks[id] = callback;
     return id;
   }


### PR DESCRIPTION
Dispatcher `_lastID` is not currently bound directly to the `Dispatcher` class, meaning that if multiple instances are created, they share, and increment the same variable.

In the context of isomorphic flux apps, it can make sense to use per-request flux instances on the server (as opposed to the singleton flux pattern), as this allows flux instantiating to be fully asynchronous.

When this per-request flux pattern is used, the `_lastID` should really be bound to the class to avoid shared "state", and to also avoid the very, very, very unlikely (and yet still possible) case that our ID counter surpasses the [magic JS integer limit](http://stackoverflow.com/a/307200) and we have a very annoying-to-debug issue.