### PR TITLE
Expose the Flux dependency, invariant.

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,3 +8,4 @@
  */
 
 module.exports.Dispatcher = require('./lib/Dispatcher')
+module.exports.invariant = require('./lib/invariant')


### PR DESCRIPTION
While developing a few utility libraries for some of our Flux applications, I thought it might be nice if those were broken down to use the invariant dependency so that our errors could leverage it as well and be a bit more unified with how other messages are exposed in Flux.

It's quite a simple module however, and if you think it would raise more complications then we can just mirror the behavior instead of just utilizing it directly off of `require('flux').invariant`.