### PR TITLE
Korean translation for Docs

### DIFF
--- a/docs/Actions-and-the-Dispatcher.ko-KR.md
+++ b/docs/Actions-and-the-Dispatcher.ko-KR.md
@@ -1,0 +1,42 @@
+---
+id: actions-and-the-dispatcher-ko-KR
+title: Action과 Dispatcher
+layout: docs
+category: Guides
+permalink: docs/actions-and-the-dispatcher-ko-KR.html
+next: testing-flux-applications-ko-KR
+---
+
+이 가이드는 원래 [React 블로그](http://facebook.github.io/react/blog/)에 게시된 [포스트](http://facebook.github.io/react/blog/2014/07/30/flux-actions-and-the-dispatcher.html)며 편집 후 여기에 추가되었다.
+
+
+The Dispatcher
+--------------
+
+Dispatcher는 싱글턴으로 Flux 어플리케이션의 데이터 흐름을 담당하는 중앙 허브와 같이 동작한다. 이는 본질적으로 콜백을 등록하고 등록된 콜백을 순서에 따라 실행할 수 있다. 각각의 _store_는 dispatcher에 콜백을 등록한다. 새로운 데이터가 dispatcher에 오게 되면 이 콜백은 데이터를 모든 store에 전파하기 위해 등록된 모든 콜백을 사용한다. 콜백을 실행하는 과정은 dispatch() 메소드를 통해 시작하고 데이터 페이로드 객체를 단일 인수로 포함한다. 이 페이로드는 일반적으로 _action_와 동의어로 사용된다.
+
+<figure class="diagram">
+  <img src="/flux/img/flux-simple-f8-diagram-with-client-action-1300w.png" alt="data flow in Flux with data originating from user interactions" width=650 />
+</figure>
+
+
+Actions and Action Creators
+---------------------------
+
+사용자의 어플리케이션 조작이나 웹 API의 호출 등으로 새로운 데이터가 시스템에 들어오면 데이터는 새로운 데이터와 특정 action type을 담아 _action_으로 묶는다. 종종 _action creators_라는 이름으로 헬퍼 메소드를 만드는데 action 객체를 만드는 것 뿐 아니라 action을 dispatcher로 보낼 때에도 사용한다.
+
+각 action의 차이는 type 어트리뷰트로 구분한다. 모든 store가 action을 받을 때는 이 어트리뷰트를 이용해 store에서 응답을 해야 하는가를 결정한다. Flux 어플리케이션에서는 store와 view 모두 스스로를 조작한다. 즉 외부의 객체에 의해 행동하지 않는다. action이 store로 전달될 때는 setter 메소드를 사용하는 것이 아니라 store가 미리 등록했던 콜백을 통해 store로 흘러 들어간다.
+
+store가 그 스스로 갱신되도록 하는 것은 MVC 어플리케이션에서 쉽게 찾을 수 있는 많은 혼란을 줄여준다. 모델 간에 연쇄적으로 갱신된다면 상태가 불안정하게 되고 정밀한 테스트가 매우 어렵다. Flux 어플리케이션의 객체는 고도로 결합도를 낮췄고 [디미터의 법칙](http://en.wikipedia.org/wiki/Law_of_Demeter)을 강하게 따르고 있다. 이 법칙은 시스템에 포함된 각각의 객체가 시스템에 있는 다른 객체를 가능한 한 서로 적게 알도록 만들라는 뜻이다. 이 결과로 소프트웨어는 더 관리 가능하고, 유연하고, 테스트 가능하며, 새로운 엔지니어링 팀 구성원도 쉽게 이해할 수 있게 된다.
+
+
+왜 Dispatcher가 필요할까
+---------------------
+
+어플리케이션의 규모가 커지면 여러 store 간의 의존성이 생기는 것은 불가피한 일이다. Store A는 꼭 Store B가 먼저 갱신되야 자신을 어떻게 갱신하는지 알 수 있다. dispatcher는 Store A의 콜백보다 Store B의 콜백을 먼저 실행할 수 있다. 의존성을 명확하게 선언하는 것으로 "나는 Store B이 이 행동을 처리하는 것이 끝날 때까지 기다릴 것이다" 라고 store가 dispatcher에게 이야기 할 필요가 있다. dispatcher는 이 기능을 waitFor() 메소드를 통해 제공한다.
+
+dispatch() 메소드는 단순하게 동기적으로 반복해서 모든 콜백을 실행하는 방식으로 제공된다. waitFor() 메소드가 한 콜백을 만나게 되면 콜백의 실행은 잠시 중단되고 waitFor()는 의존성을 넘어 새로운 반복 사이클을 제공한다. 그리고 나서 모든 의존성이 실행이 되면 원래의 콜백으로 돌아와 실행을 계속 진행한다.
+
+나아가, waitFor() 메소드는 같은 store의 콜백 내에서도 다른 action에 다른 방법으로 사용할 수 있다. 예를 들면 어떤 상황에서는 Store A가 Store B를 필요로 할 수 있다. 다른 상황에서 Store C를 기다려야 할 수도 있다. waitFor() 메소드에 코드 블럭을 활용해 특정 action에만 동작하도록 만들 수 있어서 의존성에 대한 미세한 조절이 가능하다.
+
+그러나 순환 의존은 문제가 발생한다. Store A가 Store B를 기다리고 그 반대로 Store B도 Store A를 기다린다면 무한 순환에 빠지게 된다. Flux의 dispatcher는 이제 이런 경우를 보호하기 위해 유용한 에러를 던지고 사용자에게 문제가 발생하였다고 알릴 수 있게 지원한다. 개발자는 세번째 store를 만들고 순환 참조를 해결하도록 만들 수 있게 되었다.

--- a/docs/Actions-and-the-Dispatcher.ko-KR.md
+++ b/docs/Actions-and-the-Dispatcher.ko-KR.md
@@ -5,6 +5,7 @@ layout: docs
 category: Guides
 permalink: docs/actions-and-the-dispatcher-ko-KR.html
 next: testing-flux-applications-ko-KR
+lang: ko-KR
 ---
 
 이 가이드는 원래 [React 블로그](http://facebook.github.io/react/blog/)에 게시된 [포스트](http://facebook.github.io/react/blog/2014/07/30/flux-actions-and-the-dispatcher.html)며 편집 후 여기에 추가되었다.

--- a/docs/Chat.ko-KR.md
+++ b/docs/Chat.ko-KR.md
@@ -5,6 +5,7 @@ layout: docs
 category: Quick Start
 permalink: docs/chat-ko-KR.html
 next: actions-and-the-dispatcher-ko-KR
+lang: ko-KR
 ---
 
 이 어플리케이션은 [ForwardJS](http://forwardjs.com/) 컨퍼런스를 위해 Flux 앱 구조를

--- a/docs/Chat.ko-KR.md
+++ b/docs/Chat.ko-KR.md
@@ -1,0 +1,20 @@
+---
+id: chat-ko-KR
+title: 튜토리얼 – Chat
+layout: docs
+category: Quick Start
+permalink: docs/chat-ko-KR.html
+next: actions-and-the-dispatcher-ko-KR
+---
+
+이 어플리케이션은 [ForwardJS](http://forwardjs.com/) 컨퍼런스를 위해 Flux 앱 구조를
+어떻게 잡아야 하는지, 그리고 `Dispatcher.waitFor()`를 활용해 dispatcher에 등록한 콜백을
+올바른 순서대로 실행하게 할 수 있게 만드는지에 관한 예제로 작성하였다.
+
+전체 예제 어플리케이션은 React 깃헙 리포지터리의 예제 폴더 내 [flux-chat](https://github.com/facebook/flux/tree/master/examples/flux-chat/)에서 찾을 수 있다.
+
+<figure class='video-container'>
+  <iframe src="//www.youtube.com/embed/i__969noyAM" frameborder="0" allowfullscreen></iframe>
+</figure>
+
+<script async class="speakerdeck-embed" data-id="39a8d3f0f6670131729a0a98c369402e" data-ratio="1.33333333333333" src="//speakerdeck.com/assets/embed.js"></script>

--- a/docs/Dispatcher.ko-KR.md
+++ b/docs/Dispatcher.ko-KR.md
@@ -1,0 +1,118 @@
+---
+id: dispatcher-ko-KR
+title: Dispatcher
+layout: docs
+category: Reference
+permalink: docs/dispatcher-ko-KR.html
+next: videos-ko-KR
+---
+
+Dispatcher는 등록된 callback에 데이터를 중계할 때 사용된다. 일반적인 pub-sub 시스템과는 다음 두 항목이 다르다:
+
+- 콜백은 이벤트를 개별적으로 구독하지 않는다. 모든 데이터 변동은 등록된 모든 콜백에 전달된다.
+- 콜백이 실행될 때 콜백의 전체나 일부를 중단할 수 있다.
+
+소스 코드를 보려면 [Dispatcher.js](https://github.com/facebook/flux/blob/master/src/Dispatcher.js)에서 확인할 수 있다.
+
+## API
+
+- **register(function callback): string**
+모든 데이터 변동이 있을 때 실행될 콜백을 등록한다. `waitFor()`에서 사용 가능한 토큰을 반환한다.
+
+- **unregister(string id): void**
+토큰으로 콜백을 제거한다.
+
+- **waitFor(array<string> ids): void**
+현재 실행한 콜백이 진행되기 전에 특정 콜백을 지연하게 한다. 데이터 변동에 응답하는 콜백에만 사용해야 한다.
+
+- **dispatch(object payload): void** 등록된 모든 콜백에 데이터를 전달한다.
+
+- **isDispatching(): boolean** 이 Dispatcher가 지금 데이터를 전달하고 있는지 확인한다.
+
+## 예시
+
+가상의 비행 목적지 양식에서 국가를 선택했을 때 기본 도시를 선택하는 예를 보자:
+
+```
+var flightDispatcher = new Dispatcher();
+
+// 어떤 국가를 선택했는지 계속 추적한다
+var CountryStore = {country: null};
+
+// 어느 도시를 선택했는지 계속 추적한다
+var CityStore = {city: null};
+
+// 선택된 도시의 기본 항공료를 계속 추적한다
+var FlightPriceStore = {price: null};
+```
+
+사용자가 선택한 도시를 변경하면 데이터를 전달한다:
+
+```
+flightDispatcher.dispatch({
+  actionType: 'city-update',
+  selectedCity: 'paris'
+});
+```
+
+이 데이터 변동은 `CityStore`가 소화한다:
+
+```
+flightDispatcher.register(function(payload) {
+  if (payload.actionType === 'city-update') {
+    CityStore.city = payload.selectedCity;
+  }
+});
+```
+
+사용자가 국가를 선택하면 데이터를 전달한다:
+
+```
+flightDispatcher.dispatch({
+  actionType: 'country-update',
+  selectedCountry: 'australia'
+});
+```
+
+이 데이터는 두 store에 의해 소화된다:
+
+```
+ CountryStore.dispatchToken = flightDispatcher.register(function(payload) {
+  if (payload.actionType === 'country-update') {
+    CountryStore.country = payload.selectedCountry;
+  }
+});
+```
+`CountryStore`가 등록한 콜백을 업데이트 할 때 반환되는 토큰을 참조값으로 저장했다. 이 토큰은 `waitFor()`
+에서 사용할 수 있고 `CityStore`가 갱신하는 것보다 먼저 `CountryStore`를 갱신하도록 보장할 수 있다.
+
+```
+CityStore.dispatchToken = flightDispatcher.register(function(payload) {
+  if (payload.actionType === 'country-update') {
+    // `CountryStore.country`는 업데이트 되지 않는다
+    flightDispatcher.waitFor([CountryStore.dispatchToken]);
+    // `CountryStore.country`는 업데이트가 될 수 있음이 보장되었다
+
+    // 새로운 국가의 기본 도시를 선택한다
+    CityStore.city = getDefaultCityForCountry(CountryStore.country);
+  }
+});
+```
+
+`waitFor()`는 다음과 같이 묶을 수 있다:
+
+```
+FlightPriceStore.dispatchToken =
+  flightDispatcher.register(function(payload) {
+    switch (payload.actionType) {
+      case 'country-update':
+      case 'city-update':
+        flightDispatcher.waitFor([CityStore.dispatchToken]);
+        FlightPriceStore.price =
+          getFlightPriceStore(CountryStore.country, CityStore.city);
+        break;
+  }
+});
+```
+
+`country-update`는 콜백이 등록된 순서 즉 `CountryStore`, `CityStore`, `FlightPriceStore` 순서로 실행되도록 보장된다.

--- a/docs/Dispatcher.ko-KR.md
+++ b/docs/Dispatcher.ko-KR.md
@@ -5,6 +5,7 @@ layout: docs
 category: Reference
 permalink: docs/dispatcher-ko-KR.html
 next: videos-ko-KR
+lang: ko-KR
 ---
 
 Dispatcher는 등록된 callback에 데이터를 중계할 때 사용된다. 일반적인 pub-sub 시스템과는 다음 두 항목이 다르다:

--- a/docs/Examples-and-Tools.ko-KR.md
+++ b/docs/Examples-and-Tools.ko-KR.md
@@ -5,6 +5,7 @@ layout: docs
 category: Community Resources
 permalink: docs/examples-and-tools-ko-KR.html
 next: react-ko-KR
+lang: ko-KR
 ---
 
 TodoMVC와 Chat 예제와 더불어 다음의 예제는 어떻게 Flux 아키텍쳐 패턴을 사용할 수 있는지 구현하고 있어 Flux를 이해하는데 도움이 될 것이다.

--- a/docs/Examples-and-Tools.ko-KR.md
+++ b/docs/Examples-and-Tools.ko-KR.md
@@ -1,0 +1,22 @@
+---
+id: examples-and-tools-ko-KR
+title: 예제와 도구
+layout: docs
+category: Community Resources
+permalink: docs/examples-and-tools-ko-KR.html
+next: react-ko-KR
+---
+
+TodoMVC와 Chat 예제와 더불어 다음의 예제는 어떻게 Flux 아키텍쳐 패턴을 사용할 수 있는지 구현하고 있어 Flux를 이해하는데 도움이 될 것이다.
+
+### NuclearMail
+
+[NuclearMail](https://github.com/ianobermiller/nuclearmail)는 Facebook 엔지니어인 Ian Obermiller가 선보인 Gmail 클라이언트 예제로 복잡한 형태의 Flux 어플리케이션은 어떻게 만드는지 확인할 수 있다.
+
+### 동형(Isomorphic) Flux
+
+"동형 JavaScript"는 JS 어플리케이션을 클라이언트와 서버에서 모두 사용하는 방식을 묘사하고 있다. React는 쉽게 HTML 서버-사이드를 표현할 수 있다. 다음 예제와 도구로 React와 Flux를 동형 어플리케이션 개발에 사용해보자.
+
+Michael Ridgway의 [Yahoo! Flux examples](https://github.com/yahoo/flux-examples)에서 Michael이 만든 [Fluxible](https://github.com/yahoo/fluxible), [Dispatchr](https://github.com/yahoo/dispatchr), [Routr](https://github.com/yahoo/routr) 같은 다양한 동형 Flux 어플리케이션 개발 도구를 살펴볼 수 있다. 
+
+Andres Suarez의 [ssr-demo-kit](https://github.com/zertosh/ssr-demo-kit)은 SoundCloud에서 동형 Flux 어플리케이션을 어떤 방식으로 구축했는지에 대한 예제 어플리케이션이다.

--- a/docs/Immutable.ko-KR.md
+++ b/docs/Immutable.ko-KR.md
@@ -5,4 +5,5 @@ layout: docs
 category: Complementary
 permalink: http://facebook.github.io/immutable-js/
 next: jest-ko-KR
+lang: ko-KR
 ---

--- a/docs/Immutable.ko-KR.md
+++ b/docs/Immutable.ko-KR.md
@@ -1,0 +1,8 @@
+---
+id: immutable-ko-KR
+title: ImmutableJS – 불변 데이터
+layout: docs
+category: Complementary
+permalink: http://facebook.github.io/immutable-js/
+next: jest-ko-KR
+---

--- a/docs/Jest.ko-KR.md
+++ b/docs/Jest.ko-KR.md
@@ -4,4 +4,5 @@ title: Jest – 단위 테스팅
 layout: docs
 category: Complementary
 permalink: http://facebook.github.io/jest/
+lang: ko-KR
 ---

--- a/docs/Jest.ko-KR.md
+++ b/docs/Jest.ko-KR.md
@@ -1,0 +1,7 @@
+---
+id: jest-ko-KR
+title: Jest – 단위 테스팅
+layout: docs
+category: Complementary
+permalink: http://facebook.github.io/jest/
+---

--- a/docs/Overview.ko-KR.md
+++ b/docs/Overview.ko-KR.md
@@ -72,7 +72,7 @@ dispatcher는 Flux 어플리케이션의 중앙 허브로 모든 데이터의 �
 
 어플리케이션의 규모가 커지게 되면 dispachter의 역할은 더욱 필수적이다. 바로 store 간에 의존성을 특정적인 순서로 callback을 실행하는 과정으로 관리하기 때문이다. Store는 다른 store의 업데이트가 끝날 때까지 선언적으로 기다릴 수 있고 끝나는 순서에 따라 스스로 갱신된다.
 
-Facebook이 실제로 사용하는를 dispatcher를 [npm](https://www.npmjs.com/package/flux), [Bower](http://bower.io/), 또는 [GitHub](https://github.com/facebook/flux)에서 확인할 수 있다.
+Facebook이 실제로 사용하는 dispatcher는 [npm](https://www.npmjs.com/package/flux), [Bower](http://bower.io/), 또는 [GitHub](https://github.com/facebook/flux)에서 확인할 수 있다.
 
 ### Stores
 

--- a/docs/Overview.ko-KR.md
+++ b/docs/Overview.ko-KR.md
@@ -1,0 +1,131 @@
+---
+id: overview-ko-KR
+title: 개요
+layout: docs
+category: Quick Start
+permalink: docs/overview-ko-KR.html
+next: todo-list-ko-KR
+---
+
+Flux는 Facebook에서 클라이언트-사이드 웹 어플리케이션을 만들기 위해 사용하는 어플리케이션 아키텍쳐다. 단방향 데이터 흐름을 활용해 뷰 컴포넌트를 구성하는 React를 보완하는 역할을 한다. 이전까지의 프레임워크와는 달리 패턴과 같은 모습을 하고 있기 때문에 수많은 새로운 코드를 작성할 필요 없이 바로 Flux를 이용해 사용할 수 있다.
+
+<figure class="video-container disassociated-with-next-sibling">
+  <iframe src="//www.youtube.com/embed/nYkdrAPrdcw?list=PLb0IAmt7-GS188xDYE-u1ShQmFFGbrk0v&start=621" frameborder="0" allowfullscreen></iframe>
+</figure>
+
+Flux 어플리케이션은 다음 핵심적인 세가지 부분으로 구성되어 있다: Dispatcher, Stores, Views(React 컴포넌트). Model-View-Controller와 혼동해서는 안된다. Controller도 물론 Flux 어플리케이션에 존재하지만 위계의 최상위에서 controller-views - views 관계로 존재하고 있다. 이 controller-views는 stores에서 데이터를 가져와 그 데이터를 자식에게 보내는 역할을 한다. 덧붙여 dispatcher를 돕는 action creator 메소드는 이 어플리케이션에서 가능한 모든 변화를 표현하는 유의적 API를 지원하는데 사용된다. Flux 업데이트 주기의 4번째 부분이라고 생각하면 유용하다.
+
+Flux는 MVC와 다르게 단방향으로 데이터가 흐른다. React view에서 사용자가 상호작용을 할 때, 그 view는 중앙의 dispatcher를 통해 action을 전파하게 된다. 어플리케이션의 데이터와 비지니스 로직을 가지고 있는 store는 action이 전파되면 이 action에 영향이 있는 모든 view를 갱신한다. 이 방식은 특히 React의 선언형 프로그래밍 스타일 즉, view가 어떤 방식으로 갱신해야 되는지 일일이 작성하지 않고서도 데이터를 변경할 수 있는 형태에서 편리하다.
+
+이 프로젝트는 파생되는 데이터를 올바르게 다루기 위해 시작되었다. 예를 들면 현재 뷰에서 읽지 않은 메시지가 강조되어 있으면서도 읽지 않은 메시지 수를 상단 바에 표시하고 싶었다. 이런 부분은 MVC에서 다루기 어려운데 메시지를 읽기 위한 단일 스레드에서 메시지 스레드 모델을 갱신해야하고 동시에 읽지 않은 메시지 수 모델을 갱신 해야하기 때문이다. 대형 MVC 어플리케이션에서 종종 나타나는 데이터 간의 의존성과 연쇄적인 갱신은 뒤얽힌 데이터 흐름을 만들고 예측할 수 없는 결과로 이끌게 된다.
+
+Flux는 store를 이용해 제어를 뒤집었다. 일관성을 유지한다는 명목으로 외부의 갱신에 의존하는 방식과 달리 Store는 갱신을 받아들이고 적절하게 조화한다. Store 바깥에 아무것도 두지 않는 방식으로 데이터의 도메인을 관리해야 할 필요가 없어져 외부의 갱신에 따른 문제를 명확하게 분리할 수 있도록 돕는다. Store는 독립적인 세계를 가지고 있어 `setAsRead()`와 같은 직접적인 setter 메소드가 없는 대신 dispatcher에 등록한 콜백을 통해 데이터를 받게 된다.
+
+## 구조와 데이터 흐름
+
+<p class="associated-with-next-sibling">
+Flux 어플리케이션에서의 데이터는 단방향으로 흐른다:
+</p>
+
+<figure class="diagram associated-with-next-sibling">
+  <img src="/flux/img/flux-simple-f8-diagram-1300w.png" alt="Flux에서의 단방향 데이터 흐름" />
+</figure>
+
+단방향 데이터 흐름은 Flux 패턴의 핵심인데 위 다이어그램은 __Flux 프로그래머를 위한 제일의 멘탈 모델__이 된다. dispatcher, store과 view는 독립적인 노드로 입력과 출력이 완전히 구분된다. action은 새로운 데이터를 포함하고 있는 간단한 객체로 _type_ 프로퍼티로 구분할 수 있다.
+
+<p class="associated-with-next-sibling">
+view는 사용자의 상호작용에 응답하기 위해 새로운 action을 만들어 시스템에 전파한다:
+</p>
+
+<figure class="diagram">
+  <img src="/flux/img/flux-simple-f8-diagram-with-client-action-1300w.png" alt="사용자 상호작용에 따른 Flux의 데이터 흐름" />
+</figure>
+
+<p class="associated-with-next-sibling">
+모든 데이터는 중앙 허브인 dispatcher를 통해 흐른다. action은 dispatcher에게 <em>action creator</em> 메소드를 제공하는데 대부분의 action은 view에서의 사용자 상호작용에서 발생한다. dispatcher는 store를 등록하기 위한 콜백을 실행한 이후에 action을 모든 store로 전달한다. 등록된 콜백을 활용해 store는 관리하고 있는 상태 중 어떤 액션이라도 관련이 있다면 전달해준다. store는 <em>change</em> 이벤트를 controller-views에게 알려주고 그 결과로 데이터 계층에서의 변화가 일어난다. Controller-views는 이 이벤트를 듣고 있다가 이벤트 핸들러가 있는 store에서 데이터를 다시 가져온다. controller-views는 스스로의 <code>setState()</code> 메소드를 호출하고 컴포넌트 트리에 속해 있는 자식 노드 모두를 다시 랜더링하게 한다.
+</p>
+
+<figure class="diagram">
+  <img src="/flux/img/flux-simple-f8-diagram-explained-1300w.png" alt="flux 데이터 흐름의 각각 순서에서 다양하게 전달되는 데이터" />
+</figure>
+
+Action creator는 라이브러리에서 제공하는 도움 메소드로 메소드 파라미터에서 action을 생성하고 _type_을 설정하거나 dispatcher에게 제공하는 역할을 한다.
+
+모든 action은 store가 dispatcher에 등록해둔 callback을 통해 모든 store에 전송된다.
+
+action에 대한 응답으로 store가 스스로 갱신을 한 다음에는 자신이 변경되었다고 모두에게 알린다.
+
+controller-view라고 불리는 특별한 view가 변경 이벤트를 듣고 새로운 데이터를 store에서 가져온 후 모든 트리에 있는 자식 view에게 새로운 데이터를 제공한다.
+
+이 구조는 함수형 반응 프로그래밍을 다시 재현하는 것을 쉽게 만들거나 데이터-흐름 프로그래밍, 흐름 기반 프로그래밍을 만드는데 쉽도록 돕는다. 어플리케이션에 흐르는 데이터 흐름이 양방향 바인딩이 아닌 단방향으로 흐르기 때문이다. 어플리케이션의 상태는 store에 의해서 관리되고 어플리케이션의 다른 부분과는 완전히 분리된 상태로 남는다. 두 store 사이에 의존성이 나타나도 둘은 엄격하게 위계가 관리되어 dispatcher에 의해 동기적으로 변경되는 방법으로 관리된다.
+
+이와 같은 구조는 우리의 어플리케이션이 _함수형 반응 프로그래밍(functional reactive programming)_이나 더 세부적으로 _데이터-흐름 프로그래밍(data-flow programming)_ 또는 _흐름 기반 프로그래밍(Flow-based programming)_을 연상하게 한다는 사실을 쉽게 떠올리게 한다. 즉 데이터의 흐름이 양방향 바인딩이 아닌 단일 방향으로 흐른다. 어플리케이션의 상태는 store에 의해 관리를 해서 어플리케이션의 다른 부분들과 결합도를 극히 낮춘 상태로 유지될 수 있다. store의 사이에서 의존성이 생긴다고 해도 dispachter에 의해 엄격한 위계가 유지되어 동기적으로 갱신되는 방식으로 관리된다.
+
+양방향 데이터 바인딩은 연속적인 갱신이 발생하고 객체 하나의 변경이 다른 객체를 변경하게 되어 실제 필요한 업데이트보다 더 많은 분량을 실행하게 된다. 어플리케이션의 규모가 커지면 데이터의 연속적인 갱신이 되는 상황에서는 사용자 상호작용의 결과가 어떤 변화를 만드는지 예측하는데 어려워진다. 갱신으로 인한 데이터 변경이 단 한 차례만 이뤄진다면 전체 시스템은 좀 더 예측 가능하게 된다.
+
+Flux의 다양한 부분을 확인할 예정인데 dispatcher부터 살펴보자.
+
+### 단일 dispatcher
+
+dispatcher는 Flux 어플리케이션의 중앙 허브로 모든 데이터의 흐름을 관리한다. 본질적으로 store의 콜백을 등록하는데 쓰이고 action을 store에 배분해주는 간단한 작동 방식으로 그 자체가 특별하게 똑똑한 것은 아니다. 각각의 store를 직접 등록하고 콜백을 제공한다. action creator가 새로운 action이 있다고 dispatcher에게 알려주면 어플리케이션에 있는 모든 store는 해당 action을 앞서 등록한 callback으로 전달 받는다.
+
+어플리케이션의 규모가 커지게 되면 dispachter의 역할은 더욱 필수적이다. 바로 store 간에 의존성을 특정적인 순서로 callback을 실행하는 과정으로 관리하기 때문이다. Store는 다른 store의 업데이트가 끝날 때까지 선언적으로 기다릴 수 있고 끝나는 순서에 따라 스스로 갱신된다.
+
+Facebook이 실제로 사용하는를 dispatcher를 [npm](https://www.npmjs.com/package/flux), [Bower](http://bower.io/), 또는 [GitHub](https://github.com/facebook/flux)에서 확인할 수 있다.
+
+### Stores
+
+Store는 어플리케이션의 상태와 로직을 포함하고 있다. store의 역할은 전통적인 MVC의 모델과 비슷하지만 많은 객체의 상태를 관리할 수 있는데 ORM 모델이 하는 것처럼 단일 레코드의 데이터를 표현하는 것도 아니고 Backbone의 컬랙션과도 다르다. store는 단순히 ORM 스타일의 객체 컬랙션을 관리하는 것을 넘어 어플리케이션 내의 개별적인 __도메인__에서 어플리케이션의 상태를 관리한다.
+
+예를 들면, Facebook의 [돌아보기 편집기](https://facebook.com/lookback/edit) 에서 지속적으로 재생된 시간과 플레이어 상태를 지속적으로 추적하기 위해 TimeStore를 활용한다. 같은 어플리케이션에서 ImageStore는 이미지 콜랙션을 지속적으로 추적한다. [TodoMVC 예제](https://github.com/facebook/flux/tree/master/examples/flux-todomvc/)의 TodoStore도 비슷하게 할 일 항목의 콜랙션을 관리한다. store는 두 모델 컬랙션의 특징을 보여주는 것과 동시에 싱글턴 모델의 논리적 도메인으로 역할을 한다.
+
+위에서 언급한 것과 같이 store는 자신을 dispatcher에 등록하고 callback을 제공한다. 이 callback은 action을 파라미터로 받는다. store의 등록된 callback의 내부에서는 switch문을 사용한 action 타입을 활용해서 action을 해석하고 store 내부 메소드에 적절하게 연결될 수 있는 훅을 제공한다. 여기서 결과적으로 action은 disaptcher를 통해 store의 상태를 갱신한다. store가 업데이트 된 후, 상태가 변경되었다는 이벤트를 중계하는 과정으로 view에게 새로운 상태를 보내주고 view 스스로 업데이트하게 만든다.
+
+### Views와 Controller-Views
+
+React는 조화롭고 자유로운 형태로 다시 랜더링 할 수 있는 view를 view 레이어로 제공한다. 복잡한 view 위계의 상위를 살펴보면 store에 의해 이벤트를 중계할 수 있는 특별한 종류의 view가 있다. 이 view를 controller-view라고 부르는데 store에서 데이터를 얻을 수 있는 glue 코드를 제공하고 데이터를 위계대로 자식들에게 전달하도록 돕는다. 페이지의 광범위한 영역을 관리하는 contoller-view를 가지게 된다.
+
+store에게 이벤트를 받으면 store의 퍼블릭 getter 메소드를 통해 새로 필요한 데이터를 처음으로 요청하게 된다. 그 과정에서 `setState()` 또는 `forceUpdate()` 메소드를 호출하게 되고 그 호출 과정에서 자체의 `render()` 메소드와 하위 모든 자식의 `render()` 메소드를 실행한다.
+
+전체적인 store의 상태를 단일 객체로 만들어 하위에 있는 view에 전달하게 되는데 다른 자식들도 필요한 부분이라면 데이터를 사용할 수 있도록 한다. 또한 controller-view는 위계의 최상위에서 마치 controller와 같은 역할을 지속적으로 수행해 하위에 있는 view가 가능한 한 순수하게, 함수적으로 유지될 수 있도록 한다. 또한 store의 전체 상태를 단일 객체로 흘려 보내는데 이 방식은 관리해야 하는 프로퍼티 수를 줄이는 효과도 있다.
+
+때때로 컴포넌트의 단순함을 유지하기 위해 위계 깊은 곳에서 contoller-views가 추가적으로 필요할 때가 있다. 중간에 contoller-views를 넣으면 특정 데이터 도메인에 관계된 위계 영역을 감싸서 독립적으로 만드는데(encapsulate) 도움이 된다. 하지만 조심해야 한다. 위계 내에서 만든 controller-view는 단일의 데이터 흐름과 상충해 잠재적으로 새로운 데이터 흐름의 시작점에서 충돌할 수 있다.
+
+내부에 controller-view를 추가하는 것을 결정할 때에는 여러 데이터 업데이트의 흐름이 위계와 다른 방향으로 흐르지 않도록 고려해 단순함의 균형을 유지해야 한다. 여러 데이터가 업데이트 되면 이상한 효과를 만들어 React의 렌더링 메소드가 다른 controller-view에 의해 반복적으로 실행되서 디버깅의 어려움을 가중할 가능성이 있다.
+내부 controller-view를 만드는 것을 결정할 때, 데이터를 갱신하기 위해 위계에서 여러 방향으로 흐르는 복잡성에 반해 단순한 컴포넌트의 이점에서 균형을 찾아야 한다. 여러 방향으로의 데이터 갱신은 이상한 효과를 만들 수 있다. 특히 React의 렌더 메소드는 여러 controller-view를 갱신하기 위해 반복적으로 실행이 되어버려 디버깅의 어려움을 가중할 수도 있다.
+
+### Actions
+
+dispatcher는 action을 호출해 데이터를 불러오고 store로 전달할 수 있도록 메소드를 제공한다. action의 생성은 dispatcher로 action을 보낼 때 의미있는 헬퍼 메소드로 포개진다. 할 일 목록 어플리케이션에서 할 일 아이템의 문구를 변경하고 싶다고 가정하자. `updateText(todoId, newText)`와 같은 함수 시그니쳐를 이용해 `TodoActions` 모듈 내에 action을 만든다. 이 메소드는 view의 이벤트 핸들러로부터 호출되어 실행할 수 있고 그 결과로 사용자 상호작용에 응답할 수 있게 된다. 이 action creator 메소드는 _type_을 추가할 수 있다. 이 type을 이용해 action이 store에서 해석될 수 있도록, 적절한 응답이 가능하도록 한다. 예시에서와 같이 `TODO_UPDATE_TEXT`와 같은 이름의 타입을 사용한다.
+
+action은 서버와 같은 다른 장소에서 올 수 있다. 예를 들면 data를 초기화 할 때 이런 과정이 발생할 수 있다. 또한 서버에서 에러 코드를 반환하거나 어플리케이션이 제공된 후에 업데이트가 있을 때 나타날 수 있다.
+
+
+### Dispatcher에 대해서
+
+앞서 언급한 것처럼 disaptcher는 store 간의 의존성을 관리할 수 있다. 이 기능은 dispatcher 클래스에 포함된 `waitFor()` 메소드를 통해 가능하다. [TodoMVC](https://github.com/facebook/flux/tree/master/examples/flux-todomvc/)는 극단적으로 단순해서 이 메소드를 사용할 필요가 없지만 복잡한 대형 어플리케이션에서는 생명과도 같다.
+
+TodoStore에 등록된 callback은 명시적으로 기다려 코드가 진행되는 동안 다른 의존성이 먼저 업데이트 되도록 기다린다:
+
+```javascript
+case 'TODO_CREATE':
+  Dispatcher.waitFor([
+    PrependedTextStore.dispatchToken,
+    YetAnotherStore.dispatchToken
+  ]);
+
+  TodoStore.create(PrependedTextStore.getText() + ' ' + action.text);
+  break;
+```
+
+`waitFor()`는 단일 인수만 받는데 disaptcher에 등록된 인덱스를 배열로 받는다. 이 인덱스를 대개 _dispatch token_이라 부른다. 그러므로 `waitForm()`을 호출하는 store는 다른 store의 상태에 따라 어떤 방식으로 자신의 상태를 갱신할 수 있는지 알 수 있게 된다.
+
+dispatch token은 `register()` 메소드에서 반환하는데 이 메소드는 callback을 dispatcher에 등록할 때 사용된다:
+
+```javascript
+PrependedTextStore.dispatchToken = Dispatcher.register(function (payload) {
+  // ...
+});
+```
+
+`waitFor()`, actions, action creator와 dispatcher에 대해서는 다음 [Flux 액션과 Dispatcher](http://facebook.github.io/react/blog/2014/07/30/flux-actions-and-the-dispatcher.html)를 참고하자.

--- a/docs/Overview.ko-KR.md
+++ b/docs/Overview.ko-KR.md
@@ -5,6 +5,7 @@ layout: docs
 category: Quick Start
 permalink: docs/overview-ko-KR.html
 next: todo-list-ko-KR
+lang: ko-KR
 ---
 
 Flux는 Facebook에서 클라이언트-사이드 웹 어플리케이션을 만들기 위해 사용하는 어플리케이션 아키텍쳐다. 단방향 데이터 흐름을 활용해 뷰 컴포넌트를 구성하는 React를 보완하는 역할을 한다. 이전까지의 프레임워크와는 달리 패턴과 같은 모습을 하고 있기 때문에 수많은 새로운 코드를 작성할 필요 없이 바로 Flux를 이용해 사용할 수 있다.

--- a/docs/React.ko-KR.md
+++ b/docs/React.ko-KR.md
@@ -5,4 +5,5 @@ layout: docs
 category: Complementary
 permalink: http://reactkr.github.io/react/
 next: immutable-ko-KR
+lang: ko-KR
 ---

--- a/docs/React.ko-KR.md
+++ b/docs/React.ko-KR.md
@@ -1,0 +1,8 @@
+---
+id: react-ko-KR
+title: React – UI 라이브러리
+layout: docs
+category: Complementary
+permalink: http://reactkr.github.io/react/
+next: immutable-ko-KR
+---

--- a/docs/Testing-Flux-Applications.ko-KR.md
+++ b/docs/Testing-Flux-Applications.ko-KR.md
@@ -1,0 +1,318 @@
+---
+id: testing-flux-applications-ko-KR
+title: Flux 어플리케이션 테스팅
+layout: docs
+category: Guides
+permalink: docs/testing-flux-applications-ko-KR.html
+next: dispatcher-ko-KR
+---
+
+이 가이드는 원래 [React 블로그](http://facebook.github.io/react/blog/)에 게시된 [포스트](http://facebook.github.io/react/blog/2014/09/24/testing-flux-applications.html)며 편집 후 여기에 추가되었다.
+
+이전 글에서 [기본적인 구조와 데이터 흐름](http://haruair.github.io/flux/docs/overview.html)를 살펴봤고 [dispatcher와 action creators](http://haruair.github.io/flux/docs/actions-and-the-dispatcher.html)를 면밀하게 검토했으며, 이 모든 것을 어떻게 조합하는지 [튜토리얼](http://haruair.github.io/flux/docs/todo-list.html)을 통해 확인했다. 이제 Facebook의 자동-모의(mocking) 테스팅 프레임워크인 [Jest](http://facebook.github.io/jest/)와 함께 Flux 어플리케이션에서 형식에 맞는 유닛 테스트를 어떻게 하는지 확인하자.
+
+Jest로 테스트하기
+--------------
+
+유닛 테스트를 수행하기 위해 완전히 고립된 어플리케이션의 _단위(unit)_를 만들기 위해 우리가 테스트 하려고 하는 코드 외에는 모두 모의(mock)로 만들 필요가 있다. Flux 어플리케이션의 사소한 다른 부분들을 Jest가 모의하게 된다. Jest와 함께 테스트하는 방법을 확인하기 위해 [TodoMVC 어플리케이션 예제](https://github.com/facebook/flux/tree/master/examples/flux-todomvc)를 확인하자.
+
+Jest를 시작하기 위해서는 다음 항목을 따라야 한다:
+
+1. `npm install`로 어플리케이션에서 필요로 하는 모든 의존 모듈을 설치하자.
+2. `__tests__/` 디렉토리를 생성해 테스트 파일을 넣는다. 여기서는 TodoStore-test.js을 생성했다.
+3. `npm install jest-cli --save-dev`를 실행한다.
+4. 다음 코드를 package.json에 추가한다.
+
+```javascript
+{
+  ...
+  "scripts": {
+    "test": "jest"
+  }
+  ...
+}
+```
+
+이제 `npm test` 명령어로 테스트를 실행할 준비가 끝났다.
+
+기본적으로 모든 모듈을 모의로 불러오게 된다. TodoStore-test.js에서 필요한 부분은 명시적으로 우리가 테스트할 모듈을 선언하는 부분으로 Jest의 `dontMock()` 메소드를 다음과 같이 활용한다.
+
+```javascript
+jest.dontMock('TodoStore');
+```
+
+이 코드는 Jest에게 TodoStore가 실제 객체로서 사용될 메소드인 것을 알려준다. Jest가 실행될 때 이 모듈 외에는 모두 모의로 불러오게 된다.
+
+
+Store 테스트하기
+--------------
+
+Facebook에서는, 어플리케이션의 상태와 로직이 존재하는 Flux store에 종종 많은 양의 유닛 테스트 커버리지를 필요로 한다. Store가 Flux 어플리케이션에서 가장 넓은 범위를 보장해야 하는 가장 중요한 부분이라는 점은 분명하지만, 언뜻 봐서는 store를 어떻게 테스트해야 할 지 이해하기 어렵다.
+
+Flux의 디자인에 의해 store는 외부에서 변경할 수 없다. 그리고 Store는 setter 메소드가 없다. 새로운 데이터가 store로 들어갈 수 있는 방법은 dispatcher에 등록된 콜백을 사용하는 방법이 유일하다.
+
+그래서 다음과 같은 _이상한 트릭_을 이용해 Flux에서 데이터가 흐르는 과정을 모의로 구현해야 한다.
+
+```javascript
+var mockRegister = MyDispatcher.register;
+var mockRegisterInfo = mockRegister.mock;
+var callsToRegister = mockRegisterInfo.calls;
+var firstCall = callsToRegister[0];
+var firstArgument = firstCall[0];
+var callback = firstArgument;
+```
+
+위 코드를 통해 store에 유일하게 데이터를 넣을 수 있는 방법인, store가 등록한 콜백을 찾아냈다.
+
+Jest 또는 모의 테스트를 처음 접한다면 위 코드에서 무슨 일을 하고 있는지 전혀 알 수 없으므로 각각 부분을 좀 더 상세히 설명하려고 한다. 여기서 `register()` 메소드로 어플리케이션의 dispatcher를 찾는다. dispatcher는 store가 콜백을 등록하기 위해 사용하는 부분이다. dispatcher는 Jest가 자동으로 모의 데이터를 심어주기 때문에, 모의 데이터가 들어있는 버전의 `register()` 메소드를 바로 참조할 수 있다. 그래서 평소 실제 코드에서 이 메소드를 사용하는 방식과 동일하게 사용하면 된다. 차이가 있다면 메소드에 대한 추가적인 정보로 `mock` _프로퍼티_를 얻을 수 있다는 점이다. 메소드에는 일반적으로 프로퍼티가 없지만 Jest에서는 필수적으로 활용되는 방식이다. 모의된 모든 객체의 메소드는 이 프로퍼티를 가지고 있어서 테스트가 진행되는 동안 메소드가 어떻게 동작하는지 검사해볼 수 있다. `register()`에서 호출한 순서에 따라 정렬된 목록은 `mock`의 `calls` 프로퍼티에서 확인할 수 있으며, 각각의 call은 각각 메소드를 호출할 때 사용한 인수 목록을 담고 있다.
+
+그래서 이 코드는 "MyDispatcher의 `register()` 메소드가 첫번째 호출에서 사용한 첫번째 인수 참조를 주세요"라는 뜻이다. 그렇게 구한 첫번째 인수가 바로 store의 콜백이므로 테스트에서 사용할 모든 부분이 준비되었다. 먼저 세미콜론을 아끼기 위해 한 줄로 작성해보자:
+
+```javascript
+callback = MyDispatcher.register.mock.calls[0][0];
+```
+
+이제 어플리케이션의 dispatcher나 action creator와는 독립적으로, 우리가 원하면 언제든 콜백을 호출할 수 있다. dispatcher와 action creator의 행동을 속여 콜백을 실행하는 것으로 이제 필요한 테스트를 직접 할 수 있다.
+
+```javascript
+var action = {
+  actionType: TodoConstants.TODO_CREATE,
+  text: 'foo'
+};
+callback(action);
+var all = TodoStore.getAll();
+var keys = Object.keys(all);
+expect(all[keys[0]].text).toEqual('foo');
+```
+
+모두 한 곳에 집어넣기
+----------------
+
+Flux의 TodoMVC 예제 어플리케이션은 TodoStore를 위한 예제 테스트가 추가되어 확인할 수 있지만 다음 요약 버전 테스트를 살펴보도록 하자. 이 테스트에서 확인해야 할 가장 중요한 부분은 store에 등록된 콜백을 테스트의 클로저 내에서 어떻게 계속 참조하는지, 그리고 어떻게 store를 다시 생성해서 매 테스트마다 store의 전체 상태를 깨끗하게 유지하고 있는가 하는 점이다.
+
+```javascript
+jest.dontMock('../TodoStore');
+jest.dontMock('object-assign');
+
+describe('TodoStore', function() {
+
+  var TodoConstants = require('../../constants/TodoConstants');
+  var AppDispatcher;
+  var TodoStore;
+  var callback;
+
+  // action을 모의함
+  var actionTodoCreate = {
+    actionType: TodoConstants.TODO_CREATE,
+    text: 'foo'
+  };
+  var actionTodoDestroy = {
+    actionType: TodoConstants.TODO_DESTROY,
+    id: 'replace me in test'
+  };
+
+  beforeEach(function() {
+    AppDispatcher = require('../../dispatcher/AppDispatcher');
+    TodoStore = require('../TodoStore');
+    callback = AppDispatcher.register.mock.calls[0][0];
+  });
+
+  it('registers a callback with the dispatcher', function() {
+    expect(AppDispatcher.register.mock.calls.length).toBe(1);
+  });
+
+  it('initializes with no to-do items', function() {
+    var all = TodoStore.getAll();
+    expect(all).toEqual({});
+  });
+
+  it('creates a to-do item', function() {
+    callback(actionTodoCreate);
+    var all = TodoStore.getAll();
+    var keys = Object.keys(all);
+    expect(keys.length).toBe(1);
+    expect(all[keys[0]].text).toEqual('foo');
+  });
+
+  it('destroys a to-do item', function() {
+    callback(actionTodoCreate);
+    var all = TodoStore.getAll();
+    var keys = Object.keys(all);
+    expect(keys.length).toBe(1);
+    actionTodoDestroy.id = keys[0];
+    callback(actionTodoDestroy);
+    expect(all[keys[0]]).toBeUndefined();
+  });
+
+});
+```
+
+[TodoStore의 테스트 전체 코드](https://github.com/facebook/flux/tree/master/examples/flux-todomvc/js/stores/__tests__/TodoStore-test.js)는 Github에서 직접 확인할 수 있다.
+
+
+다른 Store에서 파생된 데이터 모의하기
+-----------------------------
+
+Store에서 다른 store으로부터 나온 데이터를 필요로 할 때가 있다. 모든 모듈이 모의로 동작하기 때문에 다른 store에서 오는 데이터도 해당 store에서 오는 것처럼 흉내내야 한다. 모의 함수를 사용하고 반환되는 값을 조작하는 것으로 이 과정을 모의 할 수 있다.
+
+```javascript
+var MyOtherStore = require('../MyOtherStore');
+MyOtherStore.getState.mockReturnValue({
+  '123': {
+    id: '123',
+    text: 'foo'
+  },
+  '456': {
+    id: '456',
+    text: 'bar'
+  }
+});
+```
+
+이제 테스트에서 MyOtherStore.getState()를 호출하면 언제든 위에서 작성한 객체 컬랙션을 받게 된다. 반환되는 값을 모의하는 방법과 store가 등록한 콜백을 사용하는 기법을 사용하면 어떤 어플리케이션의 상태라도 모의로 테스트 할 수 있다.
+
+이 기법의 예제는 Flux Chat 예제에 포함된 [UnreadThreadStore-test.js](https://github.com/facebook/flux/tree/master/examples/flux-chat/js/stores/__tests__/UnreadThreadStore-test.js) 에서 확인할 수 있다.
+
+`mock` 프로퍼티의 모의 메소드에 대한 정보나 반환 값을 조작하는 방법을 Jest에서 어떻게 지원하는지에 대해 알고 싶다면 Jest 문서의 [mock functions](http://facebook.github.io/jest/docs/mock-functions.html)를 참고하자.
+
+
+React에서 Store로 로직 옮기기
+-------------------------
+
+React 컴포넌트에 있는 겉보기엔 얌전한, 작은 로직 조각이 종종 유닛 테스트를 만드는 동안 문제를 만든다. 테스트를 작성하게 되면 그 테스트가 어플리케이션의 행동에 대한 명세와 같이 작성되기를 원한다. 하지만 어플리케이션의 로직이 view 레이어에 포함되어 있다면 이 과정은 점점 어려워진다.
+
+예를 들어, 사용자가 각각의 할 일 항목을 완료한 것으로 표시하게 될 때, TodoMVC 명세로서 "모든 할 일 항목을 완료로 표시" 체크박스의 상태를 자동으로 변경하도록 만들고자 한다. 이 로직을 만들 때 다음 MainSection의 `render()` 메소드처럼 코드를 작성하고 싶은 유혹에 빠진다:
+
+```javascript
+var allTodos = this.props.allTodos;
+var allChecked = true;
+for (var id in allTodos) {
+  if (!allTodos[id].complete) {
+    allChecked = false;
+    break;
+  }
+}
+...
+
+return (
+  <section id="main">
+  <input
+    id="toggle-all"
+    type="checkbox"
+    checked={allChecked ? 'checked' : ''}
+  />
+  ...
+  </section>
+);
+```
+
+이 예제 어플리케이션 로직은 쉽고 평범하게 처리할 수 있는 부분이지만 view에 포함되어 있기 때문에 TodoStore의 테스트에서 명세 스타일로 묘사할 수 없다. 이 로직을 store로 옮겨보자. 먼저 store에 퍼블릭 메소드를 생성해서 이 로직을 캡슐화한다:
+
+```javascript
+areAllComplete: function() {
+  for (var id in _todos) {
+    if (!_todos[id].complete) {
+      return false;
+    }
+  }
+  return true;
+},
+```
+
+이제 어플리케이션의 로직이 속한 대로 다음 테스트를 작성할 수 있다:
+
+```javascript
+it('determines whether all to-do items are complete', function() {
+  var i = 0;
+  for (; i < 3; i++) {
+    callback(mockTodoCreate);
+  }
+  expect(TodoStore.areAllComplete()).toBe(false);
+
+  var all = TodoStore.getAll();
+  for (key in all) {
+    callback({
+      source: 'VIEW_ACTION',
+      action: {
+        actionType: TodoConstants.TODO_COMPLETE,
+        id: key
+      }
+    });
+  }
+  expect(TodoStore.areAllComplete()).toBe(true);
+
+  callback({
+    source: 'VIEW_ACTION',
+    action: {
+      actionType: TodoConstants.TODO_UNDO_COMPLETE,
+      id: key
+    }
+  });
+  expect(TodoStore.areAllComplete()).toBe(false);
+});
+```
+
+마지막으로 view 레이어를 수정한다. 데이터를 controller-view인 TodoApp.js에서 불러 MainSection 컴포넌트로 흘려 보낸다.
+
+```javascript
+function getTodoState() {
+  return {
+    allTodos: TodoStore.getAll(),
+    areAllComplete: TodoStore.areAllComplete()
+  };
+}
+
+var TodoApp = React.createClass({
+...
+
+  /**
+   * @return {object}
+   */
+  render: function() {
+    return (
+      ...
+      <MainSection
+        allTodos={this.state.allTodos}
+        areAllComplete={this.state.areAllComplete}
+      />
+      ...
+    );
+  },
+
+  /**
+   *  TodoStore에서 온, '변경' 이벤트를 위한 이벤트 핸들러
+   */
+  _onChange: function() {
+    this.setState(getTodoState());
+  }
+
+});
+```
+
+그리고 체크박스를 표시하기 위한 프로퍼티로 사용한다.
+
+```javascript
+render: function() {
+  ...
+
+  return (
+    <section id="main">
+    <input
+      id="toggle-all"
+      type="checkbox"
+      checked={this.props.areAllComplete ? 'checked' : ''}
+    />
+    ...
+    </section>
+  );
+},
+```
+
+React 컴포넌트 자체를 테스트하는 방법을 배우려면 [React를 위한 Jest 튜토리얼](http://facebook.github.io/jest/docs/tutorial-react.html)과 [ReactTestUtils 문서](http://facebook.github.io/react/docs/test-utils.html)를 참곻나다.
+
+
+더 읽을 거리
+---------
+
+- [Mocks Aren't Stubs](http://martinfowler.com/articles/mocksArentStubs.html) by Martin Fowler
+- [Jest API Reference](http://facebook.github.io/jest/docs/api.html)

--- a/docs/Testing-Flux-Applications.ko-KR.md
+++ b/docs/Testing-Flux-Applications.ko-KR.md
@@ -5,6 +5,7 @@ layout: docs
 category: Guides
 permalink: docs/testing-flux-applications-ko-KR.html
 next: dispatcher-ko-KR
+lang: ko-KR
 ---
 
 이 가이드는 원래 [React 블로그](http://facebook.github.io/react/blog/)에 게시된 [포스트](http://facebook.github.io/react/blog/2014/09/24/testing-flux-applications.html)며 편집 후 여기에 추가되었다.

--- a/docs/TodoList.ko-KR.md
+++ b/docs/TodoList.ko-KR.md
@@ -5,6 +5,7 @@ layout: docs
 category: Quick Start
 permalink: docs/todo-list-ko-KR.html
 next: chat-ko-KR
+lang: ko-KR
 ---
 
 Flux 아키텍쳐를 설명하기 위해 전형적인 TodoMVC 어플리케이션을 만들려고 한다. 이 어플리케이션 전체는 React 깃헙 리포지터리 [flux-todomvc](https://github.com/facebook/flux/tree/master/examples/flux-todomvc/) 예제 폴더에서 받을 수 있지만 이 예제에서 개발 단계를 하나씩 살펴보도록 하자.

--- a/docs/TodoList.ko-KR.md
+++ b/docs/TodoList.ko-KR.md
@@ -1,0 +1,592 @@
+---
+id: todo-list-ko-KR
+title: 튜토리얼 – 할 일 목록
+layout: docs
+category: Quick Start
+permalink: docs/todo-list-ko-KR.html
+next: chat-ko-KR
+---
+
+Flux 아키텍쳐를 설명하기 위해 전형적인 TodoMVC 어플리케이션을 만들려고 한다. 이 어플리케이션 전체는 React 깃헙 리포지터리 [flux-todomvc](https://github.com/facebook/flux/tree/master/examples/flux-todomvc/) 예제 폴더에서 받을 수 있지만 이 예제에서 개발 단계를 하나씩 살펴보도록 하자.
+
+처음 시작할 때에 모듈을 구동하기 위해 기본적인 구조가 필요하다. CommonJS를 기반으로 한 Node의 모듈 시스템은 상황에 잘 맞고 [react-boilerplate](https://github.com/petehunt/react-boilerplate)를 활용해 빠르게 설정하고 구동할 수 있다. npm이 설치되어 있다는 가정 하에 react-boilerplate를 깃헙에서 복제한 후 해당 디렉토리에 터미널로(또는 본인이 사용하고 싶은 CLI 어플리케이션으로) 이동한다. 그리고 다음 npm 스크립트를 통해 환경을 만들고 구동한다. `npm install`, `npm run build` 그리고 마지막에 `npm start`로 Browserify를 이용한 지속적인 빌드를 시작한다.
+
+TodoMVC 예제를 사용한다면 이미 포함되어 있는 내용이지만, react-boilerplate를 사용한다면 package.json을 수정해서 파일 구조와 의존성에 관한 내용을 TodoMVC의 예제에 포함된 [package.json](https://github.com/facebook/flux/tree/master/examples/flux-todomvc/package.json)에 맞춰준다. 이 작업을 하지 않으면 여기서 설명하는 내용과 다를 수 있다.
+
+
+소스 코드 구조
+-----------
+index.html 파일이 바로 앱의 시작점이다. 이 파일에서는 Browserify에 의해 만들어진 bundle.js를 불러오는 역할을 하고 있으며 이제부터 작성하는 대부분의 코드는 'js' 디렉토리에 넣을 예정이다. Browserify가 이 작업을 하게 두고 새로운 터미널 또는 GUI 파일 브라우저를 열어 디렉토리를 살펴보면 다음과 같은 구조로 구성되어 있다:
+
+```
+myapp
+  |
+  + ...
+  + js
+    |
+    + app.js
+    + bundle.js // 파일을 변경하면 Browserify가 자동으로 생성함
+  + index.html
+  + ...
+```
+
+js 디렉토리를 살펴보면 다음과 같은 초기 디렉토리 구조로 구성되어 있다:
+
+```
+myapp
+  |
+  + ...
+  + js
+    |
+    + actions
+    + components // 모든 React 컴포넌트 즉 view와 controller-views가 들어있음
+    + constants
+    + dispatcher
+    + stores
+    + app.js
+    + bundle.js
+  + index.html
+  + ...
+```
+
+Dispatcher 생성하기
+-----------------
+
+이제 dispatcher를 만들 준비가 되었다. Dispatcher 클래스에 대한 작은 예제가 여기에 있다. JavaScript의 promise 패턴으로 작성되어 있고 Jake Archibald의 [ES6-Promises](https://github.com/jakearchibald/ES6-Promises) 모듈로 가구현되어(polyfilled) 있다.
+
+```javascript
+var Promise = require('es6-promise').Promise;
+var assign = require('object-assign');
+
+var _callbacks = [];
+var _promises = [];
+
+var Dispatcher = function() {};
+Dispatcher.prototype = assign({}, Dispatcher.prototype, {
+
+  /**
+   * Store의 콜백을 Dispatcher에 등록하면 action에 의해 실행됨.
+   * @param {function} callback 등록하려고 하는 콜백
+   * @return {number} _cllbacks 배열에 포함될 콜백에 대한 인덱스
+   */
+  register: function(callback) {
+    _callbacks.push(callback);
+    return _callbacks.length - 1; // index
+  },
+
+  /**
+   * dispatch
+   * @param  {object} payload action으로 넘어온 데이터
+   */
+  dispatch: function(payload) {
+    // 콜백을 참조하기 위해 promise 배열을 생성
+    var resolves = [];
+    var rejects = [];
+    _promises = _callbacks.map(function(_, i) {
+      return new Promise(function(resolve, reject) {
+        resolves[i] = resolve;
+        rejects[i] = reject;
+      });
+    });
+    // 콜백에 데이터를 전파해 promise를 해결(resolve)하거나 거절(reject)함
+    _callbacks.forEach(function(callback, i) {
+      // 콜백은 객체를 반환해 해결하거나 Promise 방식으로 체이닝 할 수 있음
+      // waitFor()를 보면 이 방식이 유용하다는 것을 알 수 있음
+      Promise.resolve(callback(payload)).then(function() {
+        resolves[i](payload);
+      }, function() {
+        rejects[i](new Error('Dispatcher callback unsuccessful'));
+      });
+    });
+    _promises = [];
+  }
+});
+
+module.exports = Dispatcher;
+```
+기본적으로 Dispatcher 클래스가 제공하는 공개 API는 register()와 dispatch() 두 메소드다. 각각 store의 콜백을 등록하기 위해서 store 내에서 register() 메소드를 사용한다. 그리고 콜백을 실행하기 위해 dispatch() 메소드를 action 내에서 사용한다.
+
+앞으로 만들 app에 적합한 dispatcher인 AppDispatcher를 다음과 같이 작성한다.
+
+```javascript
+var Dispatcher = require('./Dispatcher');
+var assign = require('object-assign');
+
+var AppDispatcher = assign({}, Dispatcher.prototype, {
+
+  /**
+   * view와 dispatcher를 연결하는 다리 함수로 view action만 action으로 표시했다.
+   * 다른 변형으로는 handleServerAction이 있다.
+   * @param  {object} action view로부터 오는 데이터
+   */
+  handleViewAction: function(action) {
+    this.dispatch({
+      source: 'VIEW_ACTION',
+      action: action
+    });
+  }
+
+});
+
+module.exports = AppDispatcher;
+```
+
+이제 좀 더 요구사항에 맞는 구현을 만들었다. view의 이벤트 핸들러에서 action을 도움 함수를 이용해 전달된다. 이후에는 이 코드를 더 확장해서 서버 갱신을 위해 분리된 코드를 만들겠지만 지금은 이 정도로 충분하다.
+
+
+Store 생성하기
+------------
+
+Store를 만들기 위해 Node의 EventEmitter를 사용한다. '변경' 이벤트를 controller-views에게 중계하기 위해 EventEmitter가 필요하다. 어떻게 만드는지 여기서 살펴보려 한다. 여기에서의 코드는 일부가 생략되었는데 전체 코드를 보고 싶다면 TodoMVC 예제 코드의 [TodoStore.js](https://github.com/facebook/flux/blob/master/examples/flux-todomvc/js/stores/TodoStore.js)를 확인하자.
+
+```javascript
+var AppDispatcher = require('../dispatcher/AppDispatcher');
+var EventEmitter = require('events').EventEmitter;
+var TodoConstants = require('../constants/TodoConstants');
+var assign = require('object-assign');
+
+var CHANGE_EVENT = 'change';
+
+var _todos = {}; // 할 일 항목을 위한 컬랙션
+
+/**
+ * 할 일 항목을 생성함
+ * @param {string} text 할 일의 내용
+ */
+function create(text) {
+  // 실제 id 대신 현재의 타임스탬프를 사용함
+  var id = Date.now();
+  _todos[id] = {
+    id: id,
+    complete: false,
+    text: text
+  };
+}
+
+/**
+ * 할 일 항목을 제거함
+ * @param {string} id
+ */
+function destroy(id) {
+  delete _todos[id];
+}
+
+var TodoStore = assign({}, EventEmitter.prototype, {
+
+  /**
+   * 할 일의 전체 목록을 얻음
+   * @return {object}
+   */
+  getAll: function() {
+    return _todos;
+  },
+
+  emitChange: function() {
+    this.emit(CHANGE_EVENT);
+  },
+
+  /**
+   * @param {function} callback
+   */
+  addChangeListener: function(callback) {
+    this.on(CHANGE_EVENT, callback);
+  },
+
+  /**
+   * @param {function} callback
+   */
+  removeChangeListener: function(callback) {
+    this.removeListener(CHANGE_EVENT, callback);
+  },
+
+  dispatcherIndex: AppDispatcher.register(function(payload) {
+    var action = payload.action;
+    var text;
+
+    switch(action.actionType) {
+      case TodoConstants.TODO_CREATE:
+        text = action.text.trim();
+        if (text !== '') {
+          create(text);
+          TodoStore.emitChange();
+        }
+        break;
+
+      case TodoConstants.TODO_DESTROY:
+        destroy(action.id);
+        TodoStore.emitChange();
+        break;
+
+      // 다른 경우를 위한 actionTypes, 예를 들어 TODO_UPDATE 등
+    }
+
+    return true; // 이 반환은 문제가 없음. Dispatcher의 promise를 위해 필요.
+  })
+
+});
+
+module.exports = TodoStore;
+```
+
+위에서 작성한 코드 중에는 몇가지 중요한 부분이 있다. 맨 처음 프라이빗 데이터 구조인 _todos를 만들었다. 이 객체는 모든 개별적인 할 일 항목을 담고 있다. 이 변수는 클래스의 바깥에 있지만 모듈의 클로저로 사용된다. 그래서 프라이빗 상태로 남아 모듈 바깥에서 직접적인 변경을 할 수 없다. 이 구조는 입출력 인터페이스를 명확하게 보존할 수 있게 해 데이터의 흐름이 action을 이용하지 않고는 store 갱신을 불가능하게 한다.
+
+다른 중요한 부분은 store의 콜백을 dispatcher에 등록하는 부분이다. dispatcher에 데이터를 처리하는 콜백을 전달하고 dispatcher에 등록한 콜백을 store에 인덱스로 보존한다. 콜백 함수는 현재 2가지 actionType만 처리하고 있지만 추후에 필요한 만큼 더 추가할 수 있다.
+
+
+Controller-View 변경 리스닝하기
+----------------------------
+
+store의 변경을 듣기 위해 컴포넌트 위계의 최상위에 놓인 React 컴포넌트가 필요하다. 앱의 규모가 크다면 리스닝 컴포넌트는 더 많이 필요하게 되고 그에 따라 페이지의 모든 섹션마다 위치하게 될 것이다. Facebook의 광고 생성 도구에서 controller를 닮은 view를 많이 포함하고 있는데 각각 상세한 영역의 UI를 운영하는데 사용된다. 돌아보기 비디오 편집기에서는 프리뷰와 이미지 선택 인터페이스, 이 둘만 포함하고 있다. 여기에 TodoMVC 예제가 있다. 다시 말해서 이 코드는 요약본이며 모든 코드를 확인하고 싶다면 TodoMVC 예제의 [TodoApp.react.js](https://github.com/facebook/flux/blob/master/examples/flux-todomvc/js/components/TodoApp.react.js)를 참고하자.
+
+```javascript
+var Footer = require('./Footer.react');
+var Header = require('./Header.react');
+var MainSection = require('./MainSection.react');
+var React = require('react');
+var TodoStore = require('../stores/TodoStore');
+
+function getTodoState() {
+  return {
+    allTodos: TodoStore.getAll()
+  };
+}
+
+var TodoApp = React.createClass({
+
+  getInitialState: function() {
+    return getTodoState();
+  },
+
+  componentDidMount: function() {
+    TodoStore.addChangeListener(this._onChange);
+  },
+
+  componentWillUnmount: function() {
+    TodoStore.removeChangeListener(this._onChange);
+  },
+
+  /**
+   * @return {object}
+   */
+  render: function() {
+    return (
+      <div>
+        <Header />
+        <MainSection
+          allTodos={this.state.allTodos}
+          areAllComplete={this.state.areAllComplete}
+        />
+        <Footer allTodos={this.state.allTodos} />
+      </div>
+    );
+  },
+
+  _onChange: function() {
+    this.setState(getTodoState());
+  }
+
+});
+
+module.exports = TodoApp;
+```
+
+이제 React의 영역에 들어와 React의 생명주기 메소드를 이용한다. 이 controller-view에서 getInitialState() 메소드를 활용해 초기화하고, 이벤트 리스너를 componentDidMount() 메소드로 등록하고, componentWillUnmount()로 연결을 뒷정리한다. 여기에 포함된 div를 화면에 그려내고 TodoStore에서 받은 상태의 모음을 view의 위계에 따라 흘려 보낸다.
+
+최상단 컴포넌트는 어플리케이션을 위한 텍스트 input을 포함하고 있지만 store의 상태를 알고 있을 필요는 없다. MainSection과 Footer는 이 데이터가 필요하기 때문에 아래로 흘려보내야 한다.
+
+더 많은 Views
+------------
+React 컴포넌트 위계의 상위 레벨은 다음과 같다:
+
+```javascript
+<TodoApp>
+  <Header>
+    <TodoTextInput />
+  </Header>
+
+  <MainSection>
+    <ul>
+      <TodoItem />
+    </ul>
+  </MainSection>
+
+</TodoApp>
+```
+TodoItem이 편집 모드라면 TodoTextInput을 자식으로 생성해야 한다. 프로퍼티(props)로 받은 데이터를 컴포넌트에서 어떻게 보여주는지 살펴보고 어떻게 dispatcher가 action으로 소통하는지 알아보자.
+
+MainSection은 TodoApp에서 생성한 TodoItems서 받아온 할 일 목록을 반복해서 출력하는데 필요하다. 컴포넌트의 render()메소드로 다음과 같이 반복 출력을 표현할 수 있다:
+
+```javascript
+var allTodos = this.props.allTodos;
+
+for (var key in allTodos) {
+  todos.push(<TodoItem key={key} todo={allTodos[key]} />);
+}
+
+return (
+  <section id="main">
+    <ul id="todo-list">{todos}</ul>
+  </section>
+);
+```
+이제 TodoItem은 할 일 항목의 원문을 표시하고 자체 id를 사용한다. TodoMVC 예제에서 TodoItem이 사용하고 있는 모든 action을 설명하는 것은 이 글의 취지와는 거리가 멀지만 할 일 항목을 삭제하는 action을 살펴보려고 한다. 축약된 버전의 TodoItem은 다음과 같다:
+
+```javascript
+var React = require('react');
+var TodoActions = require('../actions/TodoActions');
+var TodoTextInput = require('./TodoTextInput.react');
+
+var TodoItem = React.createClass({
+
+  propTypes: {
+    todo: React.PropTypes.object.isRequired
+  },
+
+  render: function() {
+    var todo = this.props.todo;
+
+    return (
+      <li
+        key={todo.id}>
+        <label>
+          {todo.text}
+        </label>
+        <button className="destroy" onClick={this._onDestroyClick} />
+      </li>
+    );
+  },
+
+  _onDestroyClick: function() {
+    TodoActions.destroy(this.props.todo.id);
+  }
+
+});
+
+module.exports = TodoItem;
+```
+
+TodoActions에서 action을 삭제하는 것도 가능하다. Store가 이런 방식의 핸들링에 이미 준비되어 있기 때문에 사용자의 상호작용과 연결해 어플리케이션의 상태를 변경하는 것은 아주 간단한 일이다. 해야 할 일은 onClick 핸들러로 제거할 action을 감싸고 id만 제공해주면 끝이다. 이제 사용자는 제거 버튼을 클릭해 Flux 사이클이 어플리케이션의 남은 부분을 갱신하게 할 수 있다.
+
+반면 텍스트 입력은 약간 복잡한데 텍스트 입력의 상태를 React 컴포넌트 스스로가 업데이트 하지 않도록 잠시 멈춰야 하기 때문이다. TodoTextInput이 어떤 방식으로 동작하는가 확인해보자. 다음 보게될 내용에서는, 입력창에 값을 입력할 때, 값이 변하는 매 순간마다 React는 컴포넌트의 상태를 갱신하려고 한다. 그래서 입력창 안에 텍스트를 저장할 준비가 완료되었을 때, 컴포넌트 상태에 묶여있던 값을 action에 적재해야 한다.
+
+이 부분은 어플리케이션의 상태가 아니라 UI의 상태인데 이 둘을 잘 구분해서 생각하면 이 상태가 어디에 보관되어 있어야 하는가에 대한 좋은 지침이 된다. 모든 어플리케이션의 상태는 store에 저장된다. 반면 UI의 상태는 때때로 컴포넌트에 저장이 된다. 물론 이상적으로는 React 컴포넌트는 가능한 한 작은 상태를 유지해야 한다.
+
+어플리케이션 내에서 TodoTextInput은 여러 곳에 위치할 수 있는데다 다른 행동을 필요로 할 수 있기 때문인데 컴포넌트의 부모에게 물려받은 프로퍼티와 같이 onSave 메소드를 사용해야 하는 경우가 있을 것이다. 다음 구현으로 동일한 onSave 메소드를 사용하더라도 어디에 위치했는가에 따라 다른 action을 실행하는 것이 가능하다.
+
+```javascript
+var React = require('react');
+var ReactPropTypes = React.PropTypes;
+
+var ENTER_KEY_CODE = 13;
+
+var TodoTextInput = React.createClass({
+
+  propTypes: {
+    className: ReactPropTypes.string,
+    id: ReactPropTypes.string,
+    placeholder: ReactPropTypes.string,
+    onSave: ReactPropTypes.func.isRequired,
+    value: ReactPropTypes.string
+  },
+
+  getInitialState: function() {
+    return {
+      value: this.props.value || ''
+    };
+  },
+
+  /**
+   * @return {object}
+   */
+  render: function() /*object*/ {
+    return (
+      <input
+        className={this.props.className}
+        id={this.props.id}
+        placeholder={this.props.placeholder}
+        onBlur={this._save}
+        onChange={this._onChange}
+        onKeyDown={this._onKeyDown}
+        value={this.state.value}
+        autoFocus={true}
+      />
+    );
+  },
+
+  /**
+   * onSave 메소드를 콜백에 값을 넘겨 실행하는 방법으로 활용해
+   * 컴포넌트가 다른 방식으로 사용될 수 있도록 한다.
+   */
+  _save: function() {
+    this.props.onSave(this.state.value);
+    this.setState({
+      value: ''
+    });
+  },
+
+  /**
+   * @param {object} event
+   */
+  _onChange: function(/*object*/ event) {
+    this.setState({
+      value: event.target.value
+    });
+  },
+
+  /**
+   * @param {object} event
+   */
+
+  _onKeyDown: function(event) {
+    if (event.keyCode === ENTER_KEY_CODE) {
+      this._save();
+    }
+  }
+
+});
+
+module.exports = TodoTextInput;
+```
+
+TodoTextInput이 새로운 할 일 항목을 생성하는 프로퍼티로 onSave 메소드를 사용할 수 있도록 Header를 다음과 같이 작성한다:
+
+```javascript
+var React = require('react');
+var TodoActions = require('../actions/TodoActions');
+var TodoTextInput = require('./TodoTextInput.react');
+
+var Header = React.createClass({
+
+  /**
+   * @return {object}
+   */
+  render: function() {
+    return (
+      <header id="header">
+        <h1>todos</h1>
+        <TodoTextInput
+          id="new-todo"
+          placeholder="What needs to be done?"
+          onSave={this._onSave}
+        />
+      </header>
+    );
+  },
+
+  /**
+   * TodoTextInput와 함께 이벤트 핸들러가 호출된다.
+   * 다음과 같이 정의하는 것으로 TodoTextInput를 여러 위치에서 다양한 방법으로
+   * 사용할 수 있게 된다.
+   * @param {string} text
+   */
+  _onSave: function(text) {
+    TodoActions.create(text);
+  }
+
+});
+
+module.exports = Header;
+```
+
+다른 맥락을 예를 든다면 이미 존재하는 할 일 항목을 수정하는 경우에는 onSave 콜백에서 `TodoActions.update(text)`를 실행하는 방식으로 작성한다.
+
+유의적 action 만들기
+-----------------
+
+위에서 만든 view에서 사용한 2가지 action을 다음 코드와 같이 만들 수 있다:
+
+```javascript
+/**
+ * TodoActions
+ */
+
+var AppDispatcher = require('../dispatcher/AppDispatcher');
+var TodoConstants = require('../constants/TodoConstants');
+
+var TodoActions = {
+
+  /**
+   * @param  {string} text
+   */
+  create: function(text) {
+    AppDispatcher.handleViewAction({
+      actionType: TodoConstants.TODO_CREATE,
+      text: text
+    });
+  },
+
+  /**
+   * @param  {string} id
+   */
+  destroy: function(id) {
+    AppDispatcher.handleViewAction({
+      actionType: TodoConstants.TODO_DESTROY,
+      id: id
+    });
+  },
+
+};
+
+module.exports = TodoActions;
+```
+
+여기서 보는 것과 같이 AppDispatcher.handleViewAction() 헬퍼나 TodoActions.create() 메소드를 꼭 사용해야 할 필요는 없다. 이론적으로는 AppDispatcher.dispatch()를 직접 호출해서 데이터를 제공할 수 있다. 하지만 어플리케이션이 규모가 커지는 경우에 이 헬퍼는 코드를 깨끗하고 유의미하게 유지할 수 있도록 돕는다. 단순하게 봐도 TodoItem에 필요 없는 모든 코드를 작성하는 것보다 TodoActions.destroy(id)를 사용하는 쪽이 낫다.
+
+TodoActions.create()로 적재하는 데이터는 다음과 같다:
+
+```javascript
+{
+  source: 'VIEW_ACTION',
+  action: {
+    type: 'TODO_CREATE',
+    text: 'Write blog post about Flux'
+  }
+}
+```
+
+이 데이터는 등록된 콜백을 통해 TodoStore에게 제공된다. TodoStore는 '변경' 이벤트를 중계하고 MainSection은 TodoStore에서 새 할 일 목록을 가져오는 것으로 응답하고 상태를 변경한다. 상태의 변화는 TodoApp 컴포넌트가 자신의 render() 메소드와 모든 자식 컴포넌트의 render()메소드를 호출하는 동기가 된다.
+
+시작하기
+------
+
+이 어플리케이션의 시작점이 되는 파일은 app.js이다. 이 파일은 간단하게 TodoApp 컴포넌트로 어플리케이션의 최상위 엘리먼트를 구현한다.
+
+```javascript
+var React = require('react');
+
+var TodoApp = require('./components/TodoApp.react');
+
+React.render(
+  <TodoApp />,
+  document.getElementById('todoapp')
+);
+```
+
+Dispatcher로 의존성 관리하기
+------------------------
+
+앞서 말한 것처럼 Dispatcher 구현은 약간 세련되지 않다. 꽤 괜찮은 편이지만 대부분의 어플리케이션에서는 충분하지 않을 것이다. 각 Store 사이의 의존성을 관리할 수 있는 방법이 필요하다. 이를 위해 주요 몸체가 되는 Dispatcher 클래스에 waitFor() 메소드를 이용해 기능을 추가해보자.
+
+필요한 것은 waitFor()를 구현하는 것이다. Store 콜백으로부터 반환해 사용할 수 있도록 Promise 패턴을 사용한다.
+
+```javascript
+  /**
+   * @param  {array} promisesIndexes
+   * @param  {function} callback
+   */
+  waitFor: function(promiseIndexes, callback) {
+    var selectedPromises = promiseIndexes.map(function(index) {
+      return _promises[index];
+    });
+    return Promise.all(selectedPromises).then(callback);
+  }
+```
+
+이제 TodoStore 콜백에서 다른 의존성이 먼저 명시적으로 업데이트 될 때까지 진행되지 않고 기다릴 수 있게 되었다. 하지만 Store A가 Store B를 기다리고 B가 A를 기다리는 경우에는 순환 의존이 발생할 수 있다. 더 튼튼한 dispatcher가 필요하다면 이런 시나리오에서 콘솔에 경고를 띄우는 등 문제를 알려주는 부분도 구현해야 한다.
+
+Flux의 미래
+---------
+
+Facebook이 Flux를 오픈소스 프레임워크로 계속 릴리즈 할 것인가를 물어본다. 사실 Flux는 아키텍쳐지 프레임워크가 아니다. 그 질문이 Flux를 사용하기 쉽게 도울 기반 프로젝트에 대해 궁금한 것이라면, 우리는 계속 릴리즈 할 것이다. 우리에게 더 필요한 것이 있다면 알려주길 바란다.
+
+Facebook에서 어떤 방식으로 클라이언트-사이드 어플리케이션을 만드는지 시간내어 읽어줘서 고맙다. Flux가 당신이 하는 일에 도움이 되길 기대한다.

--- a/docs/Videos.ko-KR.md
+++ b/docs/Videos.ko-KR.md
@@ -1,0 +1,30 @@
+---
+id: videos-ko-KR
+title: 비디오
+layout: docs
+category: Community Resources
+permalink: docs/videos-ko-KR.html
+next: examples-and-tools-ko-KR
+---
+
+### "Rethinking Web App Development at Facebook" - Facebook F8 Conference 2014
+
+<figure class="video-container disassociated-with-next-sibling">
+  <iframe src="//www.youtube.com/embed/nYkdrAPrdcw" frameborder="0" allowfullscreen></iframe>
+</figure>
+
+### React and Flux: Building Applications with a Unidirectional Data Flow - Forward JS 2014
+
+<figure class="video-container">
+  <iframe src="//www.youtube.com/embed/i__969noyAM" frameborder="0" allowfullscreen></iframe>
+</figure>
+
+Facebook 엔지니어 [Bill Fisher](http://twitter.com/fisherwebdev)와 [Jing Chen](http://twitter.com/jingc)이 Flux와 React에 대해서, 이 어플리케이션 아키텍쳐를 단일 데이터 흐름과 함께 어떻게 사용해 많은 코드를 깔끔하게 만들었는지에 대한 영상이다.
+
+### React and Flux - HTML5DevConf 2014
+
+<figure class="video-container">
+  <iframe src="//www.youtube.com/embed/Bic_sFiaNDI" frameborder="0" allowfullscreen></iframe>
+</figure>
+
+[Bill Fisher](http://twitter.com/fisherwebdev)가 MVC 패턴과 Flux가 어떻게 다른지에 대해 설명하고 웹 어플리케이션을 더 빠르고 관리하기 편한 코드로 깔끔하게 정리할 수 있었는가에 대한 영상이다.

--- a/docs/Videos.ko-KR.md
+++ b/docs/Videos.ko-KR.md
@@ -5,6 +5,7 @@ layout: docs
 category: Community Resources
 permalink: docs/videos-ko-KR.html
 next: examples-and-tools-ko-KR
+lang: ko-KR
 ---
 
 ### "Rethinking Web App Development at Facebook" - Facebook F8 Conference 2014

--- a/website/core/DocsSidebar.js
+++ b/website/core/DocsSidebar.js
@@ -34,7 +34,7 @@ var DocsSidebar = React.createClass({
     var first = null;
     for (var i = 0; i < metadatas.length; ++i) {
       var metadata = metadatas[i];
-      if (!previous[metadata.id]) {
+      if (!previous[metadata.id] && !metadata.lang) {
         first = metadata;
         break;
       }


### PR DESCRIPTION
This PR is related #141. The PR is included Korean Translation of all Flux documentation.

And also I've found some trouble with `DocsSidebar` cause of translation documents.

`metadata.js` is automatically created all of the documents. That makes an issue with `DocsSidebar`.
`DocsSidebar` gets all metadata and finds a head of the tree, However, there is two head exists because of multi-language documents. Thus I added the code c707915da0f9c5ffc230e1e7b880abbb36811797 what quick look up the lang property from the documents. However, I'm still not sure with this dirty solution for i18n.

I'm looking forward to feedback. Let me know if you have any suggestions or recommendations.