### PR TITLE
Prevent warnings from webpack+UglifyJs

### DIFF
--- a/src/invariant.js
+++ b/src/invariant.js
@@ -23,7 +23,9 @@
  */
 
 var invariant = function(condition, format, a, b, c, d, e, f) {
-  if (__DEV__) {
+  var dev = __DEV__;
+
+  if (dev) {
     if (format === undefined) {
       throw new Error('invariant requires an error message argument');
     }


### PR DESCRIPTION
We've been seeing the following warnings from webpack's UglifyJsPlugin:
```
WARNING in sombrero.min.js from UglifyJs
Condition always false [./~/flux/lib/invariant.js:26,6]
Dropping unreachable code [./~/flux/lib/invariant.js:27,4]
```
Not a big deal, but we'd like to eliminate noise in our build pipeline.

To remove the warning, `__DEV__` is assigned to a variable. Even though the condition is always false and the code is equally unreachable, UglifyJs is happy.

Tests pass:
```
% jest
Using Jest CLI v0.4.0
 PASS  __tests__/Dispatcher-test.js (0.168s)
1 test passed (1 total)
Run time: 0.413s
```