### PR TITLE
Don't mock keymirror when testing TodoStore

### DIFF
--- a/examples/flux-todomvc/js/stores/__tests__/TodoStore-test.js
+++ b/examples/flux-todomvc/js/stores/__tests__/TodoStore-test.js
@@ -9,6 +9,7 @@
  * TodoStore-test
  */
 
+jest.dontMock('keymirror');
 jest.dontMock('../../constants/TodoConstants');
 jest.dontMock('../TodoStore');
 jest.dontMock('object-assign');


### PR DESCRIPTION
TodoConstants module is not mocked but jest is mocking keymirror module that is
in use by TodoConstants. I had to turn mocking off on keymirror to get
TodoConstants to return a correct map in the tests.