### PR TITLE
Clean the promises after resolve or reject

### DIFF
--- a/docs/TodoList.md
+++ b/docs/TodoList.md
@@ -94,11 +94,12 @@ Dispatcher.prototype = assign({}, Dispatcher.prototype, {
       // See waitFor() for why this might be useful.
       Promise.resolve(callback(payload)).then(function() {
         resolves[i](payload);
+        _promises.splice(i, 1);
       }, function() {
         rejects[i](new Error('Dispatcher callback unsuccessful'));
+        _promises.splice(i, 1);
       });
     });
-    _promises = [];
   }
 });
 


### PR DESCRIPTION
I think the `_promises` member in the `Dispatcher` is cleared to soon (flux documentation in the todo list example). If you clear it right after the `forEach` loop, changes are the callbacks have not resolved. So if you call `waitFor` then it seems that all the promises are already resolved, because the `_promises` arraty is empty. My solution is to splice the array after resolving.