### PR TITLE
'areAllComplete' passed as a prop, but not present in example code.

### DIFF
--- a/docs/TodoList.md
+++ b/docs/TodoList.md
@@ -275,7 +275,6 @@ var TodoApp = React.createClass({
         <Header />
         <MainSection
           allTodos={this.state.allTodos}
-          areAllComplete={this.state.areAllComplete}
         />
         <Footer allTodos={this.state.allTodos} />
       </div>


### PR DESCRIPTION
The docs has a stripped down version of the actualTodoApp.react.js in the repo. 'areAllComplete' is passed as a prop, but is not really a part of the initial state (or) TodoStore
FYI, the complete example linked via github has 'areAllComplete'. But in this example, we might not need it as it might confuse the readers.
