### PR TITLE
change bundle.js to bundle.min.js in index.html for examples

### DIFF
--- a/examples/flux-chat/index.html
+++ b/examples/flux-chat/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <section id="react"></section>
-    <script src="js/bundle.js"></script>
+    <script src="js/bundle.min.js"></script>
   </body>
 </html>

--- a/examples/flux-todomvc/index.html
+++ b/examples/flux-todomvc/index.html
@@ -13,6 +13,6 @@
       <p>Created by <a href="http://facebook.com/bill.fisher.771">Bill Fisher</a></p>
       <p>Part of <a href="http://todomvc.com">TodoMVC</a></p>
     </footer>
-    <script src="js/bundle.js"></script>
+    <script src="js/bundle.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
The `build` command compiles to a js file called `bundle.min.js`, but the `index.html` tries to load `bundle.js`.