### PR TITLE
Patch ChatWebAPIUtils createMessage function in flux-chat example

### DIFF
--- a/examples/flux-chat/js/utils/ChatWebAPIUtils.js
+++ b/examples/flux-chat/js/utils/ChatWebAPIUtils.js
@@ -29,7 +29,7 @@ module.exports = {
     ChatServerActionCreators.receiveAll(rawMessages);
   },
 
-  createMessage: function(message, threadName) {
+  createMessage: function(message) {
     // simulate writing to a database
     var rawMessages = JSON.parse(localStorage.getItem('messages'));
     var timestamp = Date.now();
@@ -38,7 +38,7 @@ module.exports = {
     var createdMessage = {
       id: id,
       threadID: threadID,
-      threadName: threadName,
+      threadName: message.threadName,
       authorName: message.authorName,
       text: message.text,
       timestamp: timestamp


### PR DESCRIPTION
Remove threadName argument from ChatWebAPIUtils.createMessage function because (1) the parameter is omitted when called from ChatMessageActionCreators and (2) the existing message parameter already contains the message theadName data.
