### PR TITLE
fixed typo

### DIFF
--- a/examples/flux-chat/js/stores/ThreadStore.js
+++ b/examples/flux-chat/js/stores/ThreadStore.js
@@ -28,7 +28,7 @@ var ThreadStore = assign({}, EventEmitter.prototype, {
     rawMessages.forEach(function(message) {
       var threadID = message.threadID;
       var thread = _threads[threadID];
-      if (thread && thread.lastTimestamp > message.timestamp) {
+      if (thread && thread.lastMessage.timestamp > message.timestamp) {
         return;
       }
       _threads[threadID] = {


### PR DESCRIPTION
Thread object has no `lastTimestamp` property, hence the condition is not valid. The main task of this iteration is to keep an object of the data of the last message, so the fix is to have the comparison condition between the `timestamp`s of the last kept message and the current one from the iteration.