### PR TITLE
Remove type attribute in script tag

### DIFF
--- a/website/core/Site.js
+++ b/website/core/Site.js
@@ -21,9 +21,6 @@ var Site = React.createClass({
           <meta property="og:description" content="Application Architecture for Building User Interfaces" />
 
           <link rel="stylesheet" href="/flux/css/flux.css" />
-
-          <script type="text/javascript" src="//use.typekit.net/vqa1hcx.js"></script>
-          <script type="text/javascript">{'try{Typekit.load();}catch(e){}'}</script>
         </head>
         <body>
 
@@ -46,6 +43,8 @@ var Site = React.createClass({
           </div>
 
           <div id="fb-root" />
+          <script src="//use.typekit.net/vqa1hcx.js"></script>
+          <script>{'try{Typekit.load();}catch(e){}'}</script>
           <script dangerouslySetInnerHTML={{__html: `
             (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
             (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
refs https://github.com/facebook/react/pull/4349

"text/javascript" is default value of the type attribute. So we don't need to write it.

And, Modified script tags position. (I was inspired by https://developers.google.com/speed/docs/insights/BlockingJS .)