### PR TITLE
Add flow types to dispatcher

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,13 @@
+[ignore]
+.*/examples/.*
+.*/lib/.*
+.*/node_modules/gulp-babel/.*
+.*/node_modules/jest-cli/.*
+
+[include]
+
+[libs]
+flow
+
+[options]
+module.system=haste

--- a/flow/flow.js
+++ b/flow/flow.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) 2014-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+declare var __DEV__: boolean;

--- a/src/__tests__/Dispatcher-test.js
+++ b/src/__tests__/Dispatcher-test.js
@@ -11,20 +11,20 @@ jest.dontMock('../Dispatcher');
 jest.dontMock('../invariant');
 __DEV__ = true; // simulate dev environment to test if errors are thrown
 
-describe('Dispatcher', function() {
+describe('Dispatcher', () => {
 
-  var Dispatcher = require('../Dispatcher');
+  var Dispatcher = require('Dispatcher');
   var dispatcher;
   var callbackA;
   var callbackB;
 
-  beforeEach(function() {
+  beforeEach(() => {
     dispatcher = new Dispatcher();
     callbackA = jest.genMockFunction();
     callbackB = jest.genMockFunction();
   });
 
-  it('should execute all subscriber callbacks', function() {
+  it('should execute all subscriber callbacks', () => {
     dispatcher.register(callbackA);
     dispatcher.register(callbackB);
 
@@ -46,10 +46,10 @@ describe('Dispatcher', function() {
     expect(callbackB.mock.calls[1][0]).toBe(payload);
   });
 
-  it('should wait for callbacks registered earlier', function() {
+  it('should wait for callbacks registered earlier', () => {
     var tokenA = dispatcher.register(callbackA);
 
-    dispatcher.register(function(payload) {
+    dispatcher.register((payload) => {
       dispatcher.waitFor([tokenA]);
       expect(callbackA.mock.calls.length).toBe(1);
       expect(callbackA.mock.calls[0][0]).toBe(payload);
@@ -66,8 +66,8 @@ describe('Dispatcher', function() {
     expect(callbackB.mock.calls[0][0]).toBe(payload);
   });
 
-  it('should wait for callbacks registered later', function() {
-    dispatcher.register(function(payload) {
+  it('should wait for callbacks registered later', () => {
+    dispatcher.register((payload) => {
       dispatcher.waitFor([tokenB]);
       expect(callbackB.mock.calls.length).toBe(1);
       expect(callbackB.mock.calls[0][0]).toBe(payload);
@@ -86,87 +86,101 @@ describe('Dispatcher', function() {
     expect(callbackB.mock.calls[0][0]).toBe(payload);
   });
 
-  it('should throw if dispatch() while dispatching', function() {
-    dispatcher.register(function(payload) {
+  it('should throw if dispatch() while dispatching', () => {
+    dispatcher.register((payload) => {
       dispatcher.dispatch(payload);
       callbackA();
     });
 
     var payload = {};
-    expect(function() {
+    expect(() => {
       dispatcher.dispatch(payload);
-    }).toThrow();
+    }).toThrow(
+      'Invariant Violation: Dispatch.dispatch(...): Cannot dispatch in the ' +
+      'middle of a dispatch.'
+    );
 
     expect(callbackA.mock.calls.length).toBe(0);
   });
 
-  it('should throw if waitFor() while not dispatching', function() {
+  it('should throw if waitFor() while not dispatching', () => {
     var tokenA = dispatcher.register(callbackA);
 
-    expect(function() {
+    expect(() => {
       dispatcher.waitFor([tokenA]);
-    }).toThrow();
+    }).toThrow(
+      'Invariant Violation: Dispatcher.waitFor(...): Must be invoked while ' +
+      'dispatching.'
+    );
 
     expect(callbackA.mock.calls.length).toBe(0);
   });
 
-  it('should throw if waitFor() with invalid token', function() {
+  it('should throw if waitFor() with invalid token', () => {
     var invalidToken = 1337;
 
-    dispatcher.register(function() {
+    dispatcher.register(() => {
       dispatcher.waitFor([invalidToken]);
     });
 
     var payload = {};
-    expect(function() {
+    expect(() => {
       dispatcher.dispatch(payload);
-    }).toThrow();
+    }).toThrow(
+      'Invariant Violation: Dispatcher.waitFor(...): `1337` does not map to ' +
+      'a registered callback.'
+    );
   });
 
-  it('should throw on self-circular dependencies', function() {
-    var tokenA = dispatcher.register(function(payload) {
+  it('should throw on self-circular dependencies', () => {
+    var tokenA = dispatcher.register((payload) => {
       dispatcher.waitFor([tokenA]);
       callbackA(payload);
     });
 
     var payload = {};
-    expect(function() {
+    expect(() => {
       dispatcher.dispatch(payload);
-    }).toThrow();
+    }).toThrow(
+      'Invariant Violation: Dispatcher.waitFor(...): Circular dependency ' +
+      'detected while waiting for `' + tokenA + '`.'
+    );
 
     expect(callbackA.mock.calls.length).toBe(0);
   });
 
-  it('should throw on multi-circular dependencies', function() {
-    var tokenA = dispatcher.register(function(payload) {
+  it('should throw on multi-circular dependencies', () => {
+    var tokenA = dispatcher.register((payload) => {
       dispatcher.waitFor([tokenB]);
       callbackA(payload);
     });
 
-    var tokenB = dispatcher.register(function(payload) {
+    var tokenB = dispatcher.register((payload) => {
       dispatcher.waitFor([tokenA]);
       callbackB(payload);
     });
 
-    var payload = {};
-    expect(function() {
-      dispatcher.dispatch(payload);
-    }).toThrow();
+    expect(() => {
+      dispatcher.dispatch({});
+    }).toThrow(
+      'Invariant Violation: Dispatcher.waitFor(...): Circular dependency ' +
+      'detected while waiting for `' + tokenA + '`.'
+    );
 
     expect(callbackA.mock.calls.length).toBe(0);
     expect(callbackB.mock.calls.length).toBe(0);
   });
 
-  it('should remain in a consistent state after a failed dispatch', function() {
+  it('should remain in a consistent state after a failed dispatch', () => {
     dispatcher.register(callbackA);
-    dispatcher.register(function(payload) {
+    dispatcher.register((payload) => {
       if (payload.shouldThrow) {
         throw new Error();
       }
       callbackB();
     });
 
-    expect(function() {
+    expect(() => {
       dispatcher.dispatch({shouldThrow: true});
     }).toThrow();
 
@@ -179,7 +193,7 @@ describe('Dispatcher', function() {
     expect(callbackB.mock.calls.length).toBe(1);
   });
 
-  it('should properly unregister callbacks', function() {
+  it('should properly unregister callbacks', () => {
     dispatcher.register(callbackA);
 
     var tokenB = dispatcher.register(callbackB);


### PR DESCRIPTION
Making dispatcher polymorphic allows strong type checking with flow

```javascript
type Action =
  {
    type: 'foo',
    foo: number,
  } |
  {
    type: 'bar',
    bar: string,
  };

var FooDispatcher: Dispatcher<Action> = new Dispatcher();

function acceptsNumber(x: number): void {}

FooDispatcher.register(function(action: Action) {
  switch (action.type) {
    case 'foo':
      acceptsNumber(action.foo);
      acceptsNumber(action.bar); // flow error, property not found in object
      break;

    case 'bar':
      acceptsNumber(action.bar); // flow error, string incompatible with number
      break;
  }
});

type NotAction = string;
FooDispatcher.register(function(action: NotAction) {}); // flow error

// flow error
FooDispatcher.dispatch({
  type: 'foo-typo',
  foo: 100,
});
```