### PR TITLE
Unread threads feature for the chat example.

### DIFF
--- a/examples/flux-chat/css/chatapp.css
+++ b/examples/flux-chat/css/chatapp.css
@@ -67,6 +67,10 @@
   cursor: default;
 }
 
+.thread-list-item.unread .thread-name::after {
+  content: ' •';
+}
+
 .message-author-name,
 .thread-name {
   color: #66c;

--- a/examples/flux-chat/css/chatapp.css
+++ b/examples/flux-chat/css/chatapp.css
@@ -15,6 +15,7 @@
   50%  { opacity: 1.0; }
   100% { opacity: 0.0; }
 }
+
 @keyframes myanim {
   0%   { opacity: 0.0; }
   50%  { opacity: 1.0; }

--- a/examples/flux-chat/css/chatapp.css
+++ b/examples/flux-chat/css/chatapp.css
@@ -10,6 +10,17 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+@-webkit-keyframes myanim {
+  0%   { opacity: 0.0; }
+  50%  { opacity: 1.0; }
+  100% { opacity: 0.0; }
+}
+@keyframes myanim {
+  0%   { opacity: 0.0; }
+  50%  { opacity: 1.0; }
+  100% { opacity: 0.0; }
+}
+
 .chatapp {
   font-family: 'Muli', 'Helvetica Neue', helvetica, arial;
   max-width: 760px;
@@ -69,6 +80,8 @@
 
 .thread-list-item.unread .thread-name::after {
   content: ' •';
+  -webkit-animation: myanim 1s infinite;
+          animation: myanim 1s infinite;
 }
 
 .message-author-name,

--- a/examples/flux-chat/js/components/ThreadListItem.react.js
+++ b/examples/flux-chat/js/components/ThreadListItem.react.js
@@ -30,7 +30,8 @@ var ThreadListItem = React.createClass({
       <li
         className={classNames({
           'thread-list-item': true,
-          'active': thread.id === this.props.currentThreadID
+          'active': thread.id === this.props.currentThreadID,
+          'unread': !(thread.lastMessage.isRead)
         })}
         onClick={this._onClick}>
         <h5 className="thread-name">{thread.name}</h5>


### PR DESCRIPTION
When I introducing in Flux application architecture throught chat example, I can't see in UI an indication for unread thdeads in thread list.
I think this feature is needed for this example. It's no critical, but I think this feature must exist.
May be without animation, but it good thing in that introducing example.

<img width="262" alt="2015-08-05 18 44 04" src="https://cloud.githubusercontent.com/assets/3241812/9090288/0e6c1060-3ba2-11e5-87b5-90a6f9dda4b3.png">

Or not? :)

Thanks.
