### PR TITLE
Remove areAllComplete from Todo Tutorial

### DIFF
--- a/docs/TodoList.ko-KR.md
+++ b/docs/TodoList.ko-KR.md
@@ -273,10 +273,7 @@ var TodoApp = React.createClass({
     return (
       <div>
         <Header />
-        <MainSection
-          allTodos={this.state.allTodos}
-          areAllComplete={this.state.areAllComplete}
-        />
+        <MainSection allTodos={this.state.allTodos} />
         <Footer allTodos={this.state.allTodos} />
       </div>
     );

--- a/docs/TodoList.md
+++ b/docs/TodoList.md
@@ -273,10 +273,7 @@ var TodoApp = React.createClass({
     return (
       <div>
         <Header />
-        <MainSection
-          allTodos={this.state.allTodos}
-          areAllComplete={this.state.areAllComplete}
-        />
+        <MainSection allTodos={this.state.allTodos} />
         <Footer allTodos={this.state.allTodos} />
       </div>
     );


### PR DESCRIPTION
The Todo Tutorial embeds abbreviated versions of the actual code, but it included `areAllComplete={this.state.areAllComplete}` in the `TodoApp` component, which isn't actually mentioned anywhere in the tutorial itself.

Since its not actually relevant to the tutorial it's probably best to remove the reference to avoid confusion.