### PR TITLE
Updated TodoMVC example to use the new FluxStore

### DIFF
--- a/examples/flux-todomvc/js/components/TodoApp.react.js
+++ b/examples/flux-todomvc/js/components/TodoApp.react.js
@@ -35,11 +35,11 @@ var TodoApp = React.createClass({
   },
 
   componentDidMount: function() {
-    TodoStore.addChangeListener(this._onChange);
+    TodoStore.addListener(this._onChange);
   },
 
   componentWillUnmount: function() {
-    TodoStore.removeChangeListener(this._onChange);
+    TodoStore.removeListener(this._onChange);
   },
 
   /**

--- a/examples/flux-todomvc/js/stores/__tests__/TodoStore-test.js
+++ b/examples/flux-todomvc/js/stores/__tests__/TodoStore-test.js
@@ -10,6 +10,9 @@
  */
 
 jest.dontMock('../../constants/TodoConstants');
+jest.dontMock('../../dispatcher/AppDispatcher');
+jest.dontMock('flux/lib/Dispatcher');
+jest.dontMock('flux/lib/FluxStore');
 jest.dontMock('../TodoStore');
 jest.dontMock('object-assign');
 
@@ -32,6 +35,8 @@ describe('TodoStore', function() {
 
   beforeEach(function() {
     AppDispatcher = require('../../dispatcher/AppDispatcher');
+    AppDispatcher.register = jest.genMockFn();
+    AppDispatcher._isDispatching = jest.genMockFn().mockReturnValue(true);
     TodoStore = require('../TodoStore');
     callback = AppDispatcher.register.mock.calls[0][0];
   });
@@ -72,7 +77,7 @@ describe('TodoStore', function() {
     expect(TodoStore.areAllComplete()).toBe(false);
 
     var all = TodoStore.getAll();
-    for (key in all) {
+    for (var key in all) {
       callback({
         actionType: TodoConstants.TODO_COMPLETE,
         id: key

--- a/examples/flux-todomvc/package.json
+++ b/examples/flux-todomvc/package.json
@@ -6,7 +6,7 @@
   "main": "js/app.js",
   "dependencies": {
     "classnames": "^2.1.3",
-    "flux": "^2.0.1",
+    "flux": "^2.1.0",
     "keymirror": "~0.1.0",
     "object-assign": "^1.0.0",
     "react": "^0.12.0"


### PR DESCRIPTION
Updated `TodoStore.js` (from the `flux-todomvc` example) so it uses the new `FluxStore` included in `flux 2.1.0`