### PR TITLE
Update jest to 0.6, fbjs, fbjs-scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,11 +43,12 @@
     "babel-core": "^5.8.22",
     "babel-loader": "^5.3.2",
     "del": "^1.2.0",
+    "fbjs-scripts": "^0.2.2",
     "gulp": "^3.9.0",
     "gulp-babel": "^5.1.0",
     "gulp-flatten": "^0.1.1",
     "gulp-util": "^3.0.6",
-    "jest-cli": "^0.4.18",
+    "jest-cli": "^0.5.10",
     "object-assign": "^3.0.0",
     "run-sequence": "^1.1.0",
     "vinyl-source-stream": "^1.0.0",
@@ -56,7 +57,7 @@
   },
   "dependencies": {
     "fbemitter": "^2.0.0",
-    "fbjs": "0.1.0-alpha.7",
+    "fbjs": "^0.4.0",
     "immutable": "^3.7.4"
   },
   "jest": {

--- a/scripts/babel/default-options.js
+++ b/scripts/babel/default-options.js
@@ -11,8 +11,8 @@
 
 var assign = require('object-assign');
 
-var babelPluginDEV = require('fbjs/scripts/babel/dev-expression');
-var babelPluginModules = require('fbjs/scripts/babel/rewrite-modules');
+var babelPluginDEV = require('fbjs-scripts/babel/dev-expression');
+var babelPluginModules = require('fbjs-scripts/babel/rewrite-modules');
 
 var moduleMap = require('fbjs/module-map');
 

--- a/scripts/jest/environment.js
+++ b/scripts/jest/environment.js
@@ -1,1 +1,1 @@
-__DEV__ = true;
+global.__DEV__ = true;

--- a/src/__tests__/Dispatcher-test.js
+++ b/src/__tests__/Dispatcher-test.js
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2014-2015, Facebook, Inc.
  * All rights reserved.
  *
@@ -10,9 +10,9 @@
 jest.dontMock('Dispatcher');
 jest.dontMock('invariant');
 
-describe('Dispatcher', () => {
+var Dispatcher = require('Dispatcher');
 
-  var Dispatcher = require('Dispatcher');
+describe('Dispatcher', () => {
   var dispatcher;
   var callbackA;
   var callbackB;
@@ -95,8 +95,7 @@ describe('Dispatcher', () => {
     expect(() => {
       dispatcher.dispatch(payload);
     }).toThrow(
-      'Invariant Violation: Dispatch.dispatch(...): Cannot dispatch in the ' +
-      'middle of a dispatch.'
+      'Dispatch.dispatch(...): Cannot dispatch in the middle of a dispatch.'
     );
 
     expect(callbackA.mock.calls.length).toBe(0);
@@ -108,8 +107,7 @@ describe('Dispatcher', () => {
     expect(() => {
       dispatcher.waitFor([tokenA]);
     }).toThrow(
-      'Invariant Violation: Dispatcher.waitFor(...): Must be invoked while ' +
-      'dispatching.'
+      'Dispatcher.waitFor(...): Must be invoked while dispatching.'
     );
 
     expect(callbackA.mock.calls.length).toBe(0);
@@ -126,8 +124,7 @@ describe('Dispatcher', () => {
     expect(() => {
       dispatcher.dispatch(payload);
     }).toThrow(
-      'Invariant Violation: Dispatcher.waitFor(...): `1337` does not map to ' +
-      'a registered callback.'
+      'Dispatcher.waitFor(...): `1337` does not map to a registered callback.'
     );
   });
 
@@ -141,8 +138,8 @@ describe('Dispatcher', () => {
     expect(() => {
       dispatcher.dispatch(payload);
     }).toThrow(
-      'Invariant Violation: Dispatcher.waitFor(...): Circular dependency ' +
-      'detected while waiting for `' + tokenA + '`.'
+      'Dispatcher.waitFor(...): Circular dependency detected while waiting ' +
+      'for `' + tokenA + '`.'
     );
 
     expect(callbackA.mock.calls.length).toBe(0);
@@ -162,8 +159,8 @@ describe('Dispatcher', () => {
     expect(() => {
       dispatcher.dispatch({});
     }).toThrow(
-      'Invariant Violation: Dispatcher.waitFor(...): Circular dependency ' +
-      'detected while waiting for `' + tokenA + '`.'
+      'Dispatcher.waitFor(...): Circular dependency detected while waiting ' +
+      'for `' + tokenA + '`.'
     );
 
     expect(callbackA.mock.calls.length).toBe(0);
@@ -215,5 +212,4 @@ describe('Dispatcher', () => {
 
     expect(callbackB.mock.calls.length).toBe(1);
   });
-
 });

--- a/src/__tests__/FluxStoreGroup-test.js
+++ b/src/__tests__/FluxStoreGroup-test.js
@@ -28,6 +28,7 @@ class SimpleStore extends FluxStore {
 describe('FluxStoreGroup', () => {
   var dispatcher;
   var storeA;
+  var storeB;
 
   beforeEach(() => {
     dispatcher = new Dispatcher();

--- a/src/stores/__tests__/FluxStore-test.js
+++ b/src/stores/__tests__/FluxStore-test.js
@@ -64,8 +64,7 @@ describe('FluxStore', () => {
     new IncompleteFluxStore(dispatcher);
     var incompleteStoreCallback = dispatcher.register.mock.calls[1][0];
     expect(() => incompleteStoreCallback({type: 'action-type'})).toThrow(
-      'Invariant Violation: IncompleteFluxStore has not overridden ' +
-      'FluxStore.__onDispatch(), which is required'
+      'IncompleteFluxStore has not overridden FluxStore.__onDispatch(), which is required'
     );
     expect(() => registeredCallback({type: 'action-type'})).not.toThrow();
   });
@@ -73,15 +72,13 @@ describe('FluxStore', () => {
   it('throws when __emitChange() is invoked outside of a dispatch', () => {
     var illegalFluxStore = new IllegalFluxStore(dispatcher);
     expect(() => illegalFluxStore.illegalEmit()).toThrow(
-      'Invariant Violation: IllegalFluxStore.__emitChange(): Must be invoked ' +
-      'while dispatching.'
+      'IllegalFluxStore.__emitChange(): Must be invoked while dispatching.'
     );
   });
 
   it('throws when hasChanged() is invoked outside of a dispatch', () => {
     expect(() => fluxStore.hasChanged()).toThrow(
-      'Invariant Violation: TestFluxStore.hasChanged(): Must be invoked ' +
-      'while dispatching.'
+      'TestFluxStore.hasChanged(): Must be invoked while dispatching.'
     );
   });
 


### PR DESCRIPTION
Fixes #288

There's probably a couple more things to do (probably should pull in the preprocessor cache busting for jest from fbjs-scripts). But this does the minimum to get us updated.