### PR TITLE
Improved the flux-chat example

### DIFF
--- a/examples/flux-chat/js/components/ThreadListItem.react.js
+++ b/examples/flux-chat/js/components/ThreadListItem.react.js
@@ -26,6 +26,7 @@ var ThreadListItem = React.createClass({
   render: function() {
     var thread = this.props.thread;
     var lastMessage = thread.lastMessage;
+    var title = (lastMessage.isRead ? '' : '* ') + thread.name;
     return (
       <li
         className={classNames({
@@ -33,7 +34,7 @@ var ThreadListItem = React.createClass({
           'active': thread.id === this.props.currentThreadID
         })}
         onClick={this._onClick}>
-        <h5 className="thread-name">{thread.name}</h5>
+        <h5 className="thread-name">{title}</h5>
         <div className="thread-time">
           {lastMessage.date.toLocaleTimeString()}
         </div>

--- a/examples/flux-chat/js/stores/ThreadStore.js
+++ b/examples/flux-chat/js/stores/ThreadStore.js
@@ -83,9 +83,9 @@ var ThreadStore = assign({}, EventEmitter.prototype, {
     }
     orderedThreads.sort(function(a, b) {
       if (a.lastMessage.date < b.lastMessage.date) {
-        return -1;
-      } else if (a.lastMessage.date > b.lastMessage.date) {
         return 1;
+      } else if (a.lastMessage.date > b.lastMessage.date) {
+        return -1;
       }
       return 0;
     });
@@ -114,6 +114,14 @@ ThreadStore.dispatchToken = ChatAppDispatcher.register(function(action) {
 
     case ActionTypes.RECEIVE_RAW_MESSAGES:
       ThreadStore.init(action.rawMessages);
+      ThreadStore.emitChange();
+      break;
+
+    case ActionTypes.RECEIVE_RAW_CREATED_MESSAGE:
+      var message = action.rawMessage;
+      var thread = ThreadStore.get(message.threadID);
+      var lastMessage = ChatMessageUtils.convertRawMessage(message, _currentID);
+      thread.lastMessage = lastMessage;
       ThreadStore.emitChange();
       break;
 


### PR DESCRIPTION
- Made the latest thread on top (more regular)
- Added a \* before unread thread title (more clear)
- Sync'd thread after message sent (more reactive)
