### PR TITLE
Removed unused promise instances from docs

### DIFF
--- a/docs/TodoList.md
+++ b/docs/TodoList.md
@@ -78,17 +78,17 @@ Dispatcher.prototype = assign({}, Dispatcher.prototype, {
    * @param  {object} payload The data from the action.
    */
   dispatch: function(payload) {
-    // First create array of promises for callbacks to reference.
-    var resolves = [];
-    var rejects = [];
     // Dispatch to callbacks and resolve/reject promises.
-    _callbacks.forEach(function(callback, i) {
-      // Callback can return an obj, to resolve, or a promise, to chain.
-      // See waitFor() for why this might be useful.
-      Promise.resolve(callback(payload)).then(function() {
-        resolves[i](payload);
-      }, function() {
-        rejects[i](new Error('Dispatcher callback unsuccessful'));
+    _callbacks.forEach(function(callback) {
+      var result = callback(payload)
+        , resultPromise = result instanceof Promise
+          ? result
+          : Promise.resolve(result);
+      
+      resultPromise.catch(function() {
+        var reason = 'Dispatcher callback unsuccessful';
+        Promise.reject(resultPromise,reason);
+        new Error(reason);
       });
     });
   }

--- a/docs/TodoList.md
+++ b/docs/TodoList.md
@@ -59,7 +59,6 @@ var Promise = require('es6-promise').Promise;
 var assign = require('object-assign');
 
 var _callbacks = [];
-var _promises = [];
 
 var Dispatcher = function() {};
 Dispatcher.prototype = assign({}, Dispatcher.prototype, {
@@ -82,12 +81,6 @@ Dispatcher.prototype = assign({}, Dispatcher.prototype, {
     // First create array of promises for callbacks to reference.
     var resolves = [];
     var rejects = [];
-    _promises = _callbacks.map(function(_, i) {
-      return new Promise(function(resolve, reject) {
-        resolves[i] = resolve;
-        rejects[i] = reject;
-      });
-    });
     // Dispatch to callbacks and resolve/reject promises.
     _callbacks.forEach(function(callback, i) {
       // Callback can return an obj, to resolve, or a promise, to chain.
@@ -98,7 +91,6 @@ Dispatcher.prototype = assign({}, Dispatcher.prototype, {
         rejects[i](new Error('Dispatcher callback unsuccessful'));
       });
     });
-    _promises = [];
   }
 });
 

--- a/docs/TodoList.md
+++ b/docs/TodoList.md
@@ -86,9 +86,8 @@ Dispatcher.prototype = assign({}, Dispatcher.prototype, {
           : Promise.resolve(result);
       
       resultPromise.catch(function() {
-        var reason = 'Dispatcher callback unsuccessful';
+        var reason = new Error('Dispatcher callback unsuccessful');
         Promise.reject(resultPromise,reason);
-        new Error(reason);
       });
     });
   }


### PR DESCRIPTION
The dispatch override returned void before, making _promises (module scoped, and otherwise unused), and its 'supporting code' unnecessary; especially for an example. I tried to maintain the intent of the code, for whatever pedantic reasons it was there before.