### PR TITLE
Fixing timestamp/date in example

### DIFF
--- a/examples/flux-chat/js/stores/ThreadStore.js
+++ b/examples/flux-chat/js/stores/ThreadStore.js
@@ -28,7 +28,7 @@ var ThreadStore = assign({}, EventEmitter.prototype, {
     rawMessages.forEach(function(message) {
       var threadID = message.threadID;
       var thread = _threads[threadID];
-      if (thread && thread.lastMessage.timestamp > message.timestamp) {
+      if (thread && thread.lastMessage.date.getTime() > message.timestamp) {
         return;
       }
       _threads[threadID] = {


### PR DESCRIPTION
Converted messages don't have timestamp property, they have date property
