### PR TITLE
Clean up .flowconfig a bit

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,21 +1,13 @@
 [ignore]
 .*/examples/.*
-.*/lib/.*
 .*/node_modules/gulp-babel/.*
 .*/node_modules/jest-cli/.*
-
-.*/flow/include/abstractMethod.js
-.*/flow/include/Dispatcher.js
-.*/flow/include/EventEmitter.js
-.*/flow/include/FluxContainer.js
-.*/flow/include/FluxMapStore.js
-.*/flow/include/FluxMixinLegacy.js
-.*/flow/include/FluxReduceStore.js
-.*/flow/include/FluxStore.js
-.*/flow/include/FluxStoreGroup.js
 
 [libs]
 flow/lib
 
 [options]
 module.system=haste
+
+[version]
+0.20.1

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ src/
 Makefile
 Flux.js
 CONTRIBUTING.md
+.flowconfig


### PR DESCRIPTION
Was poking around a bit and noticed that these entries in .flowconfig aren't necessary (with the latest flow -- 0.20.1). Also it's probably a good idea to specify the [enforced] `[version]` of Flow the repo is built against.

Figured I'd send over a PR fix this this up (or let you tell me if I'm missing something)