### PR TITLE
Updating jest-cli (flux-todomvc `npm test` fails)

### DIFF
--- a/examples/flux-chat/package.json
+++ b/examples/flux-chat/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "browserify": "^6.2.0",
     "envify": "^3.0.0",
-    "jest-cli": "^0.4.3",
+    "jest-cli": "^0.8.2",
     "reactify": "^0.15.2",
     "uglify-js": "~2.4.15",
     "watchify": "^2.1.1"

--- a/examples/flux-todomvc/package.json
+++ b/examples/flux-todomvc/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "browserify": "^6.2.0",
     "envify": "^3.0.0",
-    "jest-cli": "^0.4.3",
+    "jest-cli": "^0.8.2",
     "reactify": "^0.15.2",
     "uglify-js": "~2.4.15",
     "watchify": "^2.1.1"

--- a/examples/flux-utils-todomvc/package.json
+++ b/examples/flux-utils-todomvc/package.json
@@ -17,7 +17,7 @@
     "babelify": "^6.1.3",
     "browserify": "^6.2.0",
     "envify": "^3.0.0",
-    "jest-cli": "^0.4.3",
+    "jest-cli": "^0.8.2",
     "reactify": "^0.15.2",
     "uglify-js": "~2.4.15",
     "watchify": "^2.1.1"


### PR DESCRIPTION
flux-todomvc `npm test` fails due to https://github.com/facebook/jest/issues/340:

```
TypeError: Cannot read property 'length' of undefined
  at maybeReadMore_ (_stream_readable.js:425:18)
  at /home/xxx/node_modules/gulp-jest/node_modules/jest-cli/src/lib/FakeTimers.js:325:7
  at process._tickCallback (node.js:341:15)
```

Other examples do not fail, but upgrade any way.
I did not upgrade the main flux package.json, as the tests do not currently pass.
