### PR TITLE
Update fbjs from v0.6.x to 0.7.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "fbemitter": "^2.0.0",
-    "fbjs": "^0.6.1",
+    "fbjs": "^0.7.2",
     "immutable": "^3.7.4"
   },
   "jest": {


### PR DESCRIPTION
npm v3 tries to dedupe the dependencies by default, and keeping dependencies up-to-date helps better deduplication.

Though it seems that this repository is not tested on any CIs, I ran npm test on my PC and it passed all the tests.

```
$ npm t

> flux@2.1.1 test /Users/Shinnosuke/github/flux
> NODE_ENV=test jest

Using Jest CLI v0.5.10
 PASS  src/__tests__/Dispatcher-test.js (0.019s)
 PASS  src/__tests__/FluxStoreGroup-test.js (0.039s)
 PASS  src/stores/__tests__/FluxStore-test.js (0.04s)
 PASS  src/stores/__tests__/FluxMapStore-test.js (0.062s)
4 tests passed (4 total)
Run time: 0.935s
```
