### PR TITLE
HOC constructors propagate all arguments

### DIFF
--- a/src/FluxContainer.js
+++ b/src/FluxContainer.js
@@ -50,8 +50,8 @@ function create<DefaultProps, Props, State>(
     _fluxContainerStoreGroup: FluxStoreGroup;
     _fluxContainerSubscriptions: Array<{remove: Function}>;
 
-    constructor(props: any) {
-      super(props);
+    constructor(props: any, ...args) {
+      super(props, ...args);
       this.state = realOptions.withProps
         ? Base.calculateState(null, props)
         : Base.calculateState(null, undefined);


### PR DESCRIPTION
One example of where this would break is when using the `react-intl`'s `Container.create(injectIntl(Component))` where the `injectIntl` does an invariant check on the context.