### PR TITLE
Change FluxContainers to take initial state from wrapped React component

### DIFF
--- a/src/FluxContainer.js
+++ b/src/FluxContainer.js
@@ -52,9 +52,15 @@ function create<DefaultProps, Props, State>(
 
     constructor(props: any) {
       super(props);
-      this.state = realOptions.withProps
+
+      var calculatedState = realOptions.withProps
         ? Base.calculateState(null, props)
         : Base.calculateState(null, undefined);
+
+      this.state = {
+         ...this.state,
+         ...calculatedState
+      };
     }
 
     componentDidMount(): void {

--- a/src/FluxContainer.js
+++ b/src/FluxContainer.js
@@ -58,7 +58,7 @@ function create<DefaultProps, Props, State>(
         : Base.calculateState(null, undefined);
 
       this.state = {
-         ...this.state,
+         ...(this.state || {}),
          ...calculatedState
       };
     }

--- a/src/FluxContainer.js
+++ b/src/FluxContainer.js
@@ -59,7 +59,7 @@ function create<DefaultProps, Props, State>(
 
       this.state = {
          ...(this.state || {}),
-         ...calculatedState
+         ...calculatedState,
       };
     }
 


### PR DESCRIPTION
FluxContainers currently overwrite the `the.state` property defined in the constructor of the React component they are wrapping with the return value of `calculateState()`. This changes this behaviour to merge the return value of `calculateState()` into the current value of `this.state`.

Issue: #338 