### PR TITLE
Remove a broken link

### DIFF
--- a/docs/Examples-and-Tools.ko-KR.md
+++ b/docs/Examples-and-Tools.ko-KR.md
@@ -4,7 +4,6 @@ title: 예제와 도구
 layout: docs
 category: Community Resources
 permalink: docs/examples-and-tools-ko-KR.html
-next: react-ko-KR
 lang: ko-KR
 ---
 

--- a/docs/Examples-and-Tools.md
+++ b/docs/Examples-and-Tools.md
@@ -4,7 +4,6 @@ title: Examples and Tools
 layout: docs
 category: Community Resources
 permalink: docs/examples-and-tools.html
-next: react
 ---
 
 In addition to the TodoMVC and Chat examples, here are some more examples to help demonstrate how to use the Flux architectural pattern.


### PR DESCRIPTION
The "next" link of the following page is 404.

https://facebook.github.io/flux/docs/examples-and-tools.html#content
