### PR TITLE
Improve document titles for Docs.

### DIFF
--- a/website/core/Site.js
+++ b/website/core/Site.js
@@ -8,14 +8,18 @@ var HeaderLinks = require('HeaderLinks');
 
 var Site = React.createClass({
   render: function() {
+    var pageTitle = this.props.title
+      ? `${this.props.title} | Flux`
+      : 'Flux | Application Architecture for Building User Interfaces'
+    ;
     return (
       <html>
         <head>
           <meta charSet="utf-8" />
           <meta httpEquiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-          <title>Flux | Application Architecture for Building User Interfaces</title>
+          <title>{pageTitle}</title>
           <meta name="viewport" content="width=device-width" />
-          <meta property="og:title" content="Flux | Application Architecture for Building User Interfaces" />
+          <meta property="og:title" content={pageTitle} />
           <meta property="og:type" content="website" />
           <meta property="og:url" content="http://facebook.github.io/flux/index.html" />
           <meta property="og:description" content="Application Architecture for Building User Interfaces" />

--- a/website/layout/DocsLayout.js
+++ b/website/layout/DocsLayout.js
@@ -12,7 +12,7 @@ var DocsLayout = React.createClass({
     var metadata = this.props.metadata;
     var content = this.props.children;
     return (
-      <Site section="docs">
+      <Site section="docs" title={metadata.title}>
         <section className="content wrap documentationContent">
           <DocsSidebar metadata={metadata} />
           <div className="inner-content">


### PR DESCRIPTION
Currently, all document titles are 'Flux | Application Architecture for Building User Interfaces`.
It is a bit useless.

This PR is for fixing it.

e.g.
- http://facebook.github.io/flux/docs/overview.html#content
  - before - `Flux | Application Architecture for Building User Interfaces`
  - after - Overview | Flux
- http://facebook.github.io/flux/docs/flux-utils.html#content
  - before - `Flux | Application Architecture for Building User Interfaces`
  - after - `Flux Utils | Flux`

Thanks!
