### PR TITLE
Added areAllComplete to getTodoState function

### DIFF
--- a/docs/TodoList.md
+++ b/docs/TodoList.md
@@ -181,7 +181,8 @@ var TodoStore = require('../stores/TodoStore');
  */
 function getTodoState() {
   return {
-    allTodos: TodoStore.getAll()
+    allTodos: TodoStore.getAll(),
+    areAllComplete: TodoStore.areAllComplete()
   };
 }
 


### PR DESCRIPTION
I know this is an abbreviated code, but when I was reading this docs I got really confused where the call "this.state.allTodos" (previously in line :212) was getting the function from so I had to go to the source.

I think adding this code won't harm the brevity of the code and will make it more undestandable.
