### PR TITLE
Move React to peer dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * `FluxContainer`: Uses functional version of `setState`
 * `FluxMixin`: Subscriptions are setup in `componentWillMount` rather than
  `componentDidMount`
-* `React` added as dependency to `flux/utils`
+* `React` added as peer dependency to `flux/utils`
 * Package `dist/FluxUtils.js` alongside `dist/Flux.js`
 
 _**Note**: This is marked as a breaking change due to the large number of small

--- a/package.json
+++ b/package.json
@@ -60,7 +60,9 @@
   "dependencies": {
     "fbemitter": "^2.0.0",
     "fbjs": "^0.8.0",
-    "immutable": "^3.7.4",
+    "immutable": "^3.7.4"
+  },
+  "peerDependencies": {
     "react": "^15.0.1"
   },
   "jest": {


### PR DESCRIPTION
As discussed in #343 moving React to peer dependencies will reduce package installation time and won't install React for those who use Flux with different view library.