### PR TITLE
Proposal: Container class inherits React Component

### DIFF
--- a/src/container/FluxContainer.js
+++ b/src/container/FluxContainer.js
@@ -110,7 +110,7 @@ class FluxContainer extends Component<DefaultProps, Props, State> {
 
   componentWillReceiveProps(nextProps: Props, nextContext: any): void {
     this._fluxContainerSubscriptions.setStores(this.getStores());
-    this.setState(this.calculateState(nextProps, nextContext));
+    this.setState((prevState) => this.calculateState(prevState, nextProps, nextContext));
   }
 
   componentWillUnmount(): void {


### PR DESCRIPTION
After #352 I've started to think that `Container.create` becomes complicated and redundant.

Since `calculateState` and `getStores` are static they don't have an access to container instance, so we need to  provide this info to them. I'm not familiar with the idea of using static methods, so probably I'm doing a bad thing. This topic has to be discussed.

Another thing is `options`. By providing `{pure: true|false}`, `{withProps: true|false}` or `{withContext: true|false}` we're specifying an API that uses React's patterns. What if we can just use these patterns.

Proposed implementation provides `Container` as a class that inherits `React.Component`.

```javascript
class ThingsContainer extends Container {
  getStores() {
    return [ThingsContainer];
  }

  calculateState() {
    return {
      things: ThingsContainer.getState();
    };
  }

  render() {
    return <ThingsList things={this.state.things} />;
  }
}
```

So, here are benefits:

 1. `Container` is pure by default (as it was before). If the user needs change this behavior, they're specifying custom `shouldComponentUpdate()` (which is React's pattern) instead of API thing `{pure: false}`.
 2. `getStores()` and `calculateState()` have an access to `this.props` and `this.context` so there is no need to provide additional flags like `withProps` and `withContext`.

`FluxMixinLegacy` also needs the same updates, so I will do them after we consider this proposal as useful.