### PR TITLE
Bump Flow to 0.35.0

### DIFF
--- a/src/.flowconfig
+++ b/src/.flowconfig
@@ -26,4 +26,4 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
 
 [version]
-0.23.0
+0.35.0

--- a/src/FluxStoreGroup.js
+++ b/src/FluxStoreGroup.js
@@ -24,7 +24,7 @@ type DispatchToken = string;
  * waiting for each of the given stores.
  */
 class FluxStoreGroup {
-  _dispatcher: Dispatcher;
+  _dispatcher: Dispatcher<any>;
   _dispatchToken: DispatchToken;
 
   constructor(stores: Array<FluxStore>, callback: Function): void {
@@ -45,7 +45,7 @@ class FluxStoreGroup {
   }
 }
 
-function _getUniformDispatcher(stores: Array<FluxStore>): Dispatcher {
+function _getUniformDispatcher(stores: Array<FluxStore>): Dispatcher<any> {
   invariant(
     stores && stores.length,
     'Must provide at least one store to FluxStoreGroup'

--- a/src/stores/FluxReduceStore.js
+++ b/src/stores/FluxReduceStore.js
@@ -43,7 +43,7 @@ class FluxReduceStore<TState> extends FluxStore {
 
   _state: TState;
 
-  constructor(dispatcher: Dispatcher) {
+  constructor(dispatcher: Dispatcher<any>) {
     super(dispatcher);
     this._state = this.getInitialState();
   }

--- a/src/stores/FluxStore.js
+++ b/src/stores/FluxStore.js
@@ -31,10 +31,10 @@ class FluxStore {
   __changed: boolean;
   __changeEvent: string;
   __className: any;
-  __dispatcher: Dispatcher;
+  __dispatcher: Dispatcher<any>;
   __emitter: EventEmitter;
 
-  constructor(dispatcher: Dispatcher): void {
+  constructor(dispatcher: Dispatcher<any>): void {
     this.__className = this.constructor.name;
 
     this.__changed = false;
@@ -50,7 +50,7 @@ class FluxStore {
     return this.__emitter.addListener(this.__changeEvent, callback);
   }
 
-  getDispatcher(): Dispatcher {
+  getDispatcher(): Dispatcher<any> {
     return this.__dispatcher;
   }
 


### PR DESCRIPTION
Same version as used by React Native. Main breaking change is the deprecation of default wildcard generics for explicit generics. I didn't improve the typing (we do have a version that better typed I believe?).