### PR TITLE
Add license to flux-shell

### DIFF
--- a/examples/flux-shell/package.json
+++ b/examples/flux-shell/package.json
@@ -4,6 +4,7 @@
   "description": "Basic shell application for the Flux architecture",
   "repository": "https://github.com/facebook/flux",
   "author": "Kyle Davis",
+  "license": "BSD-3-Clause",
   "main": "bundle.js",
   "scripts": {
     "build": "webpack ./src/root.js ./bundle.js",


### PR DESCRIPTION
To get rid of warnings when working on the `my-todomvc` tutorial

```
npm WARN flux-shell@1.0.0 No license field.
```

Used the license from the root.