### PR TITLE
Improve performance of FluxContainerSubscriptions

### DIFF
--- a/src/container/FluxContainerSubscriptions.js
+++ b/src/container/FluxContainerSubscriptions.js
@@ -15,10 +15,26 @@ import type FluxStore from 'FluxStore';
 
 const FluxStoreGroup = require('FluxStoreGroup');
 
+function shallowArrayEqual(a: Array<FluxStore>, b: Array<FluxStore>): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 class FluxContainerSubscriptions {
 
   _callbacks: Array<() => void>;
   _storeGroup: ?FluxStoreGroup;
+  _stores: ?Array<FluxStore>;
   _tokens: ?Array<{remove: () => void}>;
 
   constructor() {
@@ -26,6 +42,10 @@ class FluxContainerSubscriptions {
   }
 
   setStores(stores: Array<FluxStore>): void {
+    if (this._stores && shallowArrayEqual(this._stores, stores)) {
+      return;
+    }
+    this._stores = stores;
     this._resetTokens();
     this._resetStoreGroup();
 
@@ -65,6 +85,7 @@ class FluxContainerSubscriptions {
     this._resetTokens();
     this._resetStoreGroup();
     this._resetCallbacks();
+    this._resetStores();
   }
 
   _resetTokens() {
@@ -79,6 +100,10 @@ class FluxContainerSubscriptions {
       this._storeGroup.release();
       this._storeGroup = null;
     }
+  }
+
+  _resetStores(): void {
+    this._stores = null;
   }
 
   _resetCallbacks(): void {


### PR DESCRIPTION
A `FluxContainer` recomputes the stores list (the one created by
`getStores`) after every change in `props` and `context`. It is needed
because a container can use `props` to refine how the `state` is
computed. The `FluxContainerSubscriptions` manages when a container
should be recomputed. It is done listening for changes in dependent
stores. In order to do that, `FluxContainerSubscriptions` creates a
store group that is a fake store that wait for all dependent stores.
If the stores change during the dispatching cycle, then it call the
listener which one recompute the state of the container.

This PR changes `FluxContainerSubscriptions` to only create new
listener and a new store group when the stores list changes.