### PR TITLE
Early bail from setState in componentWillReceiveProps

### DIFF
--- a/src/container/FluxContainer.js
+++ b/src/container/FluxContainer.js
@@ -153,7 +153,10 @@ function create<DefaultProps, Props, State>(
         super.componentWillReceiveProps(nextProps, nextContext);
       }
 
-      if (realOptions.withProps || realOptions.withContext) {
+      if (
+        realOptions.withProps && !shallowEqual(this.props, nextProps) ||
+        realOptions.withContext && !shallowEqual(this.context, nextContext)
+      ) {
         // Update both stores and state.
         this._fluxContainerSubscriptions.setStores(
           getStores(nextProps, nextContext),


### PR DESCRIPTION
Right now every single time the container receive props and has the withProps or withContext options we are going to schedule an extra render by calling setState, this makes render and getState to overfire. Both of this functions are blockers for frame rendering. 

In order to make this better we can add a shallow equal comparison for props and context. because getStores and getState are pure functions we can assume if we pass the same parameters we are going to get the same data.