### PR TITLE
Adding support for React 16 beta

### DIFF
--- a/examples/flux-todomvc/README.md
+++ b/examples/flux-todomvc/README.md
@@ -243,8 +243,8 @@ Now we can use this structure, along with a simple
 or copy [`Counter`](./src/data/Counter.js) then update `data/TodoStore.js`
 
 ```js
-import Counter from '../data/Counter';
-import Todo from '../data/Todo';
+import Counter from './Counter';
+import Todo from './Todo';
 
 class TodoStore extends ReduceStore {
   ...

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "fbjs": "^0.8.0"
   },
   "peerDependencies": {
-    "react": "^15.0.2 || ^16.0.0-beta || ^16.0.0"
+    "react": "^15.0.2 || ^16.0.0"
   },
   "jest": {
     "modulePathIgnorePatterns": [

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "fbjs": "^0.8.0"
   },
   "peerDependencies": {
-    "react": "^15.0.2"
+    "react": "^15.0.2 || ^16.0.0"
   },
   "jest": {
     "modulePathIgnorePatterns": [

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "fbjs": "^0.8.0"
   },
   "peerDependencies": {
-    "react": "^15.0.2 || ^16.0.0"
+    "react": "^15.0.2 || ^16.0.0-beta || ^16.0.0"
   },
   "jest": {
     "modulePathIgnorePatterns": [


### PR DESCRIPTION
This seems like the best practice to support a beta version and the official. We can optionally remove this later when the full version is released.