### PR TITLE
Correct payload type of Dispatcher in FluxReduceStore.

### DIFF
--- a/src/stores/FluxReduceStore.js
+++ b/src/stores/FluxReduceStore.js
@@ -43,7 +43,7 @@ class FluxReduceStore<TState> extends FluxStore {
 
   _state: TState;
 
-  constructor(dispatcher: Dispatcher<any>) {
+  constructor(dispatcher: Dispatcher<Object>) {
     super(dispatcher);
     this._state = this.getInitialState();
   }


### PR DESCRIPTION
The payload type of Dispatcher should be Action, which is an Object. `reduce` and `__invokeOnDispatch` methods are using correct type.