### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,9 @@
 We want to make contributing to this project as easy and transparent as
 possible.
 
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+
 ## Pull Requests
 We actively welcome your pull requests.
 


### PR DESCRIPTION
**what is the change?:**
Adding a document linking to the Facebook Open Source Code of Conduct,
for visibility and to meet Github community standards.

**why make this change?:**
Facebook Open Source provides a Code of Conduct statement for all
projects to follow.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve the [Flux Community Profile](https://github.com/facebook/flux/community)
checklist and increase the visibility of our COC.

**test plan:**
Viewing it on my branch -
<img width="1319" alt="screen shot 2017-11-24 at 10 20 30 am" src="https://user-images.githubusercontent.com/1114467/33221098-fb9a6a8e-d101-11e7-90a5-3b27bd2fc2f7.png">
<img width="1305" alt="screen shot 2017-11-24 at 10 20 38 am" src="https://user-images.githubusercontent.com/1114467/33221099-fbc60a22-d101-11e7-9474-f4b2de7bf1f7.png">

**issue:**
internal task t23481323