### PR TITLE
The js file is not obvious as in other places

### DIFF
--- a/examples/flux-todomvc/README.md
+++ b/examples/flux-todomvc/README.md
@@ -98,7 +98,7 @@ src
     └── AppView.js
 ```
 
-Set up `TodoDispatcher`. Here we just need to import dispatcher from Flux
+Set up `data/TodoDispatcher.js`. Here we just need to import dispatcher from Flux
 and instantiate a new dispatcher to use throughout the application.
 
 ```js


### PR DESCRIPTION
The following places correctly refer the js file, while this place didn't make it obvious.