### PR TITLE
Use HTTPS for homepage URL

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "version": "2.1.1",
   "main": "dist/Flux.js",
   "license": "https://github.com/facebook/flux/blob/master/LICENSE",
-  "homepage": "http://facebook.github.io/flux/",
+  "homepage": "https://facebook.github.io/flux/",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/flux.git"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "facebook",
     "dispatcher"
   ],
-  "homepage": "http://facebook.github.io/flux/",
+  "homepage": "https://facebook.github.io/flux/",
   "bugs": "https://github.com/facebook/flux/issues",
   "files": [
     "LICENSE",


### PR DESCRIPTION
Hello - I noticed that the NPM registry entry for 'flux' lists your homepage with an HTTP URL rather than HTTPS. This PR fixes it to use HTTPS.