### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ sudo: false
 language: node_js
 
 node_js:
-  - "4"
+  - "node"
+  - "10"
+  - "8"
   - "6"
 
 script:


### PR DESCRIPTION
We should test all current LTS and stable releases of Node.js.
Node.js 4 has already reached its EOL so we do not want to test there anymore.