### PR TITLE
Add documentation pointing to flux-hooks

### DIFF
--- a/docs/Flux-Utils.md
+++ b/docs/Flux-Utils.md
@@ -152,3 +152,12 @@ By default containers are pure, meaning they will not re-render when their props
 By default containers are not able to access any props. This is both for performance reasons, and to ensure that containers are re-usable and props do not have to be threaded throughout a component tree. There are some valid situations in which you need to determine your state based on both props and a store's state. In those situations pass options `{withProps: true}` as the second argument to `create()`. This will expose the components props as the second argument to `calculateState()`.
 
 If you are unable to utilize react classes most of this functionality is also mirrored in a mixin. `import {Mixin} from 'flux/utils';`
+
+# Using Flux with React Hooks
+
+React 16.8 introduced [Hooks](https://reactjs.org/docs/hooks-intro.html). Much of the functionality of flux and Flux Utils can be reproduced using [useContext](https://reactjs.org/docs/hooks-reference.html#usecontext) & [useReducer](https://reactjs.org/docs/hooks-reference.html#usereducer).
+
+## Existing Projects with Store / ReduceStore
+
+If you have existing projects that need to continue using Flux Util's Stores, you can use the [flux-hooks](https://github.com/Fieldscope/flux-hooks) package.
+Access the store using useFluxStore which provides an API similar to [Container](#container)'s calculateState.


### PR DESCRIPTION
Point documentation on how to use Flux Utils store with flux-hooks package.

Discussion in [Issue #468 ](https://github.com/facebook/flux/issues/468).