### PR TITLE
update: import React line remove errors

### DIFF
--- a/examples/flux-flow/src/AppView.js
+++ b/examples/flux-flow/src/AppView.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-import React from 'react';
+import * as React from 'react';
 
 export type Props = {value: string};
 

--- a/examples/flux-flow/src/__flowtests__/App-flowtest.js
+++ b/examples/flux-flow/src/__flowtests__/App-flowtest.js
@@ -19,7 +19,7 @@
 
 import AppDispatcher from '../AppDispatcher';
 import AppStore from '../AppStore';
-import React from 'react';
+import * as React from 'react';
 import {Container} from 'flux/utils';
 
 /**

--- a/examples/flux-flow/src/root.js
+++ b/examples/flux-flow/src/root.js
@@ -15,4 +15,5 @@ import AppContainer from './AppContainer';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+// $FlowExpectedError: element with id `root' maybe not exist.
 ReactDOM.render(<AppContainer />, document.getElementById('root'));


### PR DESCRIPTION
Note: We import React as a namespace here with import * as React from 'react' instead of as a default with import React from 'react'. When importing React as an ES module you may use either style, but importing as a namespace gives you access to React’s utility types.