### PR TITLE
feat: add DocSearch as recommended by docusaurus.

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -13,6 +13,10 @@ module.exports = {
   favicon: 'img/favicon.ico',
   organizationName: 'facebook',
   projectName: 'flux',
+  algolia: {
+      apiKey: '6dab6b592e7b8e994dc2cff2aadc3cf2',
+      indexName: 'flux',
+    },
   themeConfig: {
     navbar: {
       title: 'Flux',

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -14,9 +14,9 @@ module.exports = {
   organizationName: 'facebook',
   projectName: 'flux',
   algolia: {
-      apiKey: '6dab6b592e7b8e994dc2cff2aadc3cf2',
-      indexName: 'flux',
-    },
+    apiKey: '6dab6b592e7b8e994dc2cff2aadc3cf2',
+    indexName: 'flux',
+  },
   themeConfig: {
     navbar: {
       title: 'Flux',


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.