### PR TITLE
misc: add license badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <p align="center">
   <img src="https://facebook.github.io/flux/img/flux-logo-color.svg" alt="logo" width="20%" />
 </p>
@@ -6,6 +7,9 @@
 </h1>
 <p align="center">
   An application architecture for React utilizing a unidirectional data flow.
+  <br>
+  [![License](https://img.shields.io/badge/License-BSD%20-blue.svg)](https://github.com/facebook/flux/blob/master/LICENSE)
+  
 </p>
 
 <img src="./img/flux-diagram-white-background.png" style="width: 100%;" />

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 </h1>
 <p align="center">
   An application architecture for React utilizing a unidirectional data flow.
-  <br>
-  [![License](https://img.shields.io/badge/License-BSD%20-blue.svg)](https://github.com/facebook/flux/blob/master/LICENSE)
+
+[![License](https://img.shields.io/badge/License-BSD%20-blue.svg)](https://github.com/facebook/flux/blob/master/LICENSE)
   
 </p>
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <p align="center">
   <img src="https://facebook.github.io/flux/img/flux-logo-color.svg" alt="logo" width="20%" />
 </p>


### PR DESCRIPTION
Added the missing BSD License badge in the Readme.md file after referring to the License doc

![image](https://user-images.githubusercontent.com/33371558/90317150-ffc39780-df44-11ea-9a9c-f63d14a6f4cf.png)
