### PR TITLE
Add React 17 peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "fbjs": "^3.0.0"
   },
   "peerDependencies": {
-    "react": "^15.0.2 || ^16.0.0-beta || ^16.0.0"
+    "react": "^15.0.2 || ^16.0.0-beta || ^16.0.0" || "^17.0.0"
   },
   "jest": {
     "modulePathIgnorePatterns": [


### PR DESCRIPTION
Now that React 17 is out, this needs listed. Resolves #509.