### PR TITLE
HTML-escape error responses in flux-async example

### DIFF
--- a/examples/flux-async/package.json
+++ b/examples/flux-async/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.3",
+    "escape-html": "^1.0.3",
     "express": "^4.14.0",
     "flux": "../../.",
     "immutable": "^3.8.0",

--- a/examples/flux-async/server/app.js
+++ b/examples/flux-async/server/app.js
@@ -9,6 +9,7 @@
 
 'use strict';
 
+const escape = require('escape-html');
 const express = require('express');
 const fs = require('fs');
 const path = require('path');
@@ -427,11 +428,11 @@ function unique(arr) {
 }
 
 function missing(res, field) {
-  res.status(400).send(`Missing required query param: ${field}.`);
+  res.status(400).send(`Missing required query param: ${escape(field)}.`);
 }
 
 function missingID(res, id) {
-  res.status(404).send(`Todo not found for ID: ${id}.`);
+  res.status(404).send(`Todo not found for ID: ${escape(id)}.`);
 }
 
 function getTodos() {

--- a/examples/flux-async/server/app.js
+++ b/examples/flux-async/server/app.js
@@ -431,7 +431,7 @@ function missing(res, field) {
 }
 
 function missingID(res, id) {
-  res.status(404).send('Todo not found for ID: ${id}.');
+  res.status(404).send(`Todo not found for ID: ${id}.`);
 }
 
 function getTodos() {


### PR DESCRIPTION
The flux-async example app embeds unsanitised query parameters in HTTP error responses. Of course, it's only an example, so this isn't a real security vulnerability, but it might perhaps make sense to introduce sanitisation anyway, in case people copy it for real usage.

(In fact, the original example app is safe, since the error response is always a constant string. That seems to have been an accident, though, and I think it was meant to be a template string embedding the missing ID, cf first commit.)