### PR TITLE
website: Make announcementBarContent change style (mobile)

### DIFF
--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -69,13 +69,13 @@ div[class^="announcementBarContent"] a:hover {
 }
 
 @media only screen and (max-width: 768px) {
-  .announcement {
+  div[class^="announcementBarContent"] {
     font-size: 18px;
   }
 }
 
 @media only screen and (max-width: 500px) {
-  .announcement {
+  div[class^="announcementBarContent"] {
     font-size: 15px;
     line-height: 22px;
     padding: 6px 30px;


### PR DESCRIPTION
# Screenshots
![flux2](https://user-images.githubusercontent.com/78584173/166886757-563e9f86-645f-43e2-8b09-47242f5e8bec.png)

# Code
The actual class of banner is `.announcementBarContent_3EUC` and `.announcement` does not select the banner.
It should be `div[class^="announcementBarContent"]`